### PR TITLE
fix(linux): GPU crash-loop, X11 screen-capture failure, and clipped HUD popovers

### DIFF
--- a/electron/gpuSwitches.test.ts
+++ b/electron/gpuSwitches.test.ts
@@ -58,9 +58,8 @@ describe("getGpuSwitches", () => {
 		});
 	});
 
-	it("returns the X11 EGL workaround on Linux X11", () => {
+	it("does not force EGL on Linux X11 (default ANGLE backend)", () => {
 		expect(getGpuSwitches("linux", { XDG_SESSION_TYPE: "x11" })).toEqual({
-			useGl: "egl",
 			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
 		});
 	});

--- a/electron/gpuSwitches.ts
+++ b/electron/gpuSwitches.ts
@@ -42,7 +42,7 @@ export function shouldForceLinuxEgl(env: NodeJS.ProcessEnv): boolean {
 
 export function getGpuSwitches(
 	platform: NodeJS.Platform,
-	env: NodeJS.ProcessEnv = process.env,
+	_env: NodeJS.ProcessEnv = process.env,
 ): GpuSwitches {
 	if (platform === "darwin") {
 		return {
@@ -56,8 +56,13 @@ export function getGpuSwitches(
 	}
 
 	if (platform === "linux") {
+		// Do NOT force --use-gl=egl: native EGL (gl=egl-gles2,angle=none) is not
+		// an allowed GL implementation on Electron's Linux builds, which only
+		// ship ANGLE (gl=egl-angle). Requesting it makes the GPU process
+		// crash-loop on init, which in turn breaks screen capture and forces the
+		// renderer into software compositing. Let Chromium use its default ANGLE
+		// backend instead.
 		return {
-			useGl: shouldForceLinuxEgl(env) ? "egl" : undefined,
 			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
 		};
 	}

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -17,7 +17,7 @@ import {
 import { RECORDINGS_DIR } from "./appPaths";
 import { showCursor } from "./cursorHider";
 import { registerExtensionIpcHandlers } from "./extensions/extensionIpc";
-import { getGpuSwitches } from "./gpuSwitches";
+import { getGpuSwitches, shouldForceLinuxEgl } from "./gpuSwitches";
 import {
 	cleanupAllExportStreams,
 	cleanupNativeVideoExportSessions,
@@ -1006,28 +1006,26 @@ app.whenReady().then(async () => {
 	session.defaultSession.setDisplayMediaRequestHandler(async (_request, callback) => {
 		try {
 			const sourceId = getSelectedSourceId();
-			// On Linux/Wayland, calling desktopCapturer.getSources() itself
-			// invokes the xdg-desktop-portal picker. If we then return one of
-			// those sources, Chromium triggers a SECOND portal because the
-			// pre-enumerated source IDs are stale on Wayland. To collapse this
-			// into a single portal invocation, when the Linux portal sentinel
-			// is set we skip getSources entirely and hand back a synthetic
-			// source id; Chromium then opens the portal once to actually
-			// resolve the capture.
-			// Default to the sentinel on Linux when no source has been
-			// pre-selected (e.g. fresh session where the renderer skipped the
-			// source picker entirely). This avoids calling getSources() which
-			// would itself trigger an extra portal dialog.
+			// The synthetic sentinel source id is ONLY correct on Wayland, where
+			// Chromium resolves getDisplayMedia through xdg-desktop-portal and
+			// hand-back of a real desktopCapturer id would trigger a duplicate
+			// portal dialog. On X11 there is no portal path for getDisplayMedia:
+			// Chromium must receive a REAL desktopCapturer source id, otherwise it
+			// cannot resolve the capture and throws "Could not start video source".
+			const isWaylandSession =
+				process.platform === "linux" && !shouldForceLinuxEgl(process.env);
 			const isLinuxPortalSentinel =
-				process.platform === "linux" && (sourceId === "screen:linux-portal" || !sourceId);
+				isWaylandSession && (sourceId === "screen:linux-portal" || !sourceId);
 			if (isLinuxPortalSentinel) {
 				callback({ video: { id: "screen:0:0", name: "Entire screen" } });
 				return;
 			}
 			const sources = await desktopCapturer.getSources({ types: ["screen", "window"] });
 			const source = sourceId
-				? (sources.find((s) => s.id === sourceId) ?? sources[0])
-				: sources[0];
+				? (sources.find((s) => s.id === sourceId) ??
+					sources.find((s) => s.id.startsWith("screen:")) ??
+					sources[0])
+				: (sources.find((s) => s.id.startsWith("screen:")) ?? sources[0]);
 			if (source) {
 				callback({
 					video: { id: source.id, name: source.name },

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -301,9 +301,13 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 	}
 
 	if (!isHudOverlayMousePassthroughSupported()) {
-		if (process.platform !== "linux") {
-			setHudOverlayFallbackExpanded(!ignore);
-		}
+		// Expand the fallback overlay while the HUD is interactive so that
+		// popovers/menus have room to render. Without this the window stays at
+		// the compact 860x160 fallback and upward popovers are clipped by the
+		// window edge (e.g. only the last items visible). This previously
+		// skipped Linux, where passthrough is unsupported, so the bug showed up
+		// exactly there.
+		setHudOverlayFallbackExpanded(!ignore);
 		hudOverlayWindow.setIgnoreMouseEvents(false);
 		return;
 	}


### PR DESCRIPTION
## Summary

Three independent fixes that make Recordly usable on **Linux X11** (tested on a hybrid-GPU laptop: AMD iGPU + NVIDIA, GNOME, X11 session, Electron 39.2.7). Each is a separate commit.

### 1. GPU process crash-loops because of `--use-gl=egl` → app stuck in software compositing

`electron/gpuSwitches.ts` appended `--use-gl=egl` on Linux X11. Native EGL (`gl=egl-gles2`) is **not** an allowed GL implementation in Electron's Linux build (only `egl-angle` is), so the GPU process failed to initialize and crash-looped on every launch:

```
ERROR:ui/gl/init/gl_factory.cc:102] Requested GL implementation (gl=egl-gles2,angle=none) not found in allowed implementations: [(gl=egl-angle,angle=default)]
ERROR:components/viz/service/main/viz_main_impl.cc:189] Exiting GPU process due to errors during initialization
```

This forced the app into software compositing (the `VizCompositorTh` thread pinned near a full core even when idle) and broke features that require the GPU process. Fix: stop forcing native EGL; let Chromium use its default ANGLE backend.

### 2. `getDisplayMedia` fails with "Could not start video source" on X11

`setDisplayMediaRequestHandler` returned a **synthetic** source id `screen:0:0` on all Linux — a Wayland trick to make Chromium open the `xdg-desktop-portal` picker exactly once. On **X11 there is no portal path for `getDisplayMedia`**: Chromium must receive a *real* `desktopCapturer` source id, otherwise it cannot resolve the capture and `getDisplayMedia` rejects with `Could not start video source` (no picker shown).

Fix: gate the synthetic sentinel to Wayland only (detected via `shouldForceLinuxEgl`, which is false on Wayland). On X11, enumerate `desktopCapturer.getSources()` and return a real `screen:` source.

### 3. HUD popovers clipped / toolbar barely draggable on Linux

On Linux, `isHudOverlayMousePassthroughSupported()` returns false, so the HUD overlay uses the compact 860×160 fallback window. That fallback is meant to expand to 860×540 while the HUD is interactive (so menus/popovers render and the toolbar has room to move), but the expansion was explicitly skipped on Linux (`if (process.platform !== "linux")`). With the window stuck at 860×160, upward popovers (e.g. the countdown-delay menu) are clipped by the window edge — only the last couple of items are visible — and the toolbar has almost no room to drag.

Fix: call `setHudOverlayFallbackExpanded(!ignore)` regardless of platform. The window still shrinks back to compact when the HUD is not interactive, so the on-screen footprint stays small when idle. (The Win32 transparent-overlay corruption referenced in `main.ts` is on a different code path and unrelated.)

## Verification

Built from source and ran on the affected machine:
- After #1, the GL factory errors are gone, the GPU process initializes, and the compositor thread drops to ~0% at idle (was ~82%).
- For #2, a minimal Electron harness confirmed both `getDisplayMedia` and the legacy `getUserMedia({ chromeMediaSource: 'desktop' })` succeed once a real `desktopCapturer` source id is returned, while the synthetic id reliably fails. After the fix, recording starts correctly on X11.
- After #3, the countdown-delay menu shows all four options and the toolbar drag range is usable, with no window corruption.

Wayland behavior is unchanged (synthetic source id still used; passthrough path unaffected).

## Environment

- Ubuntu, GNOME, `XDG_SESSION_TYPE=x11`
- Hybrid AMD iGPU + NVIDIA (NVIDIA in on-demand mode)
- Electron 39.2.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux GPU handling by using the default graphics backend (avoids forcing EGL on Electron Linux).
  * Fixed screen-sharing source selection on Linux/Wayland, improving detection of the “Entire screen” option and fallback behavior when a specific source isn’t available.
  * Resolved HUD overlay mouse passthrough fallback sizing on non-passthrough cases, including Linux.
* **Tests**
  * Updated GPU switch expectations for Linux X11 coverage to match the new default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->