### PR TITLE
fix(linux): stop forcing unsupported EGL GL implementation

### DIFF
--- a/electron/gpuSwitches.test.ts
+++ b/electron/gpuSwitches.test.ts
@@ -14,13 +14,13 @@ describe("getGpuSwitches", () => {
 		});
 	});
 
-	it("returns the X11 EGL workaround on Linux X11", () => {
+	it("does not force a GL implementation on Linux X11", () => {
 		expect(getGpuSwitches("linux", { XDG_SESSION_TYPE: "x11" })).toEqual({
 			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
 		});
 	});
 
-	it("does not force a GL implementation on Linux X11", () => {
+	it("does not force a GL implementation when the session type is unknown", () => {
 		expect(getGpuSwitches("linux", {})).toEqual({
 			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
 		});

--- a/electron/gpuSwitches.test.ts
+++ b/electron/gpuSwitches.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { getGpuSwitches } from "./gpuSwitches";
 
 describe("getGpuSwitches", () => {
-	it("returns the Linux VAAPI workaround without forcing EGL on Wayland", () => {
+	it("returns the Linux VAAPI workaround without forcing a GL implementation on Wayland", () => {
 		expect(
 			getGpuSwitches("linux", {
 				XDG_SESSION_TYPE: "wayland",
@@ -20,7 +20,7 @@ describe("getGpuSwitches", () => {
 		});
 	});
 
-	it("does not force a GL implementation when the session type is unknown", () => {
+	it("does not force a GL implementation on Linux X11", () => {
 		expect(getGpuSwitches("linux", {})).toEqual({
 			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
 		});

--- a/electron/gpuSwitches.test.ts
+++ b/electron/gpuSwitches.test.ts
@@ -1,49 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getGpuSwitches, shouldForceLinuxEgl } from "./gpuSwitches";
-
-describe("shouldForceLinuxEgl", () => {
-	it("does not force EGL in a Wayland session", () => {
-		expect(
-			shouldForceLinuxEgl({
-				XDG_SESSION_TYPE: "wayland",
-				WAYLAND_DISPLAY: "wayland-0",
-			}),
-		).toBe(false);
-	});
-
-	it("does not force EGL when Wayland is explicitly requested via Ozone", () => {
-		expect(
-			shouldForceLinuxEgl({
-				OZONE_PLATFORM: "wayland",
-				XDG_SESSION_TYPE: "x11",
-			}),
-		).toBe(false);
-	});
-
-	it("falls back to Electron's ozone hint when OZONE_PLATFORM is invalid", () => {
-		expect(
-			shouldForceLinuxEgl({
-				OZONE_PLATFORM: "auto",
-				ELECTRON_OZONE_PLATFORM_HINT: "wayland",
-				XDG_SESSION_TYPE: "x11",
-			}),
-		).toBe(false);
-	});
-
-	it("forces EGL in an X11 session", () => {
-		expect(shouldForceLinuxEgl({ XDG_SESSION_TYPE: "x11" })).toBe(true);
-	});
-
-	it("forces EGL when x11 is explicitly requested via Electron's ozone hint", () => {
-		expect(
-			shouldForceLinuxEgl({
-				ELECTRON_OZONE_PLATFORM_HINT: "x11",
-				WAYLAND_DISPLAY: "wayland-0",
-			}),
-		).toBe(true);
-	});
-});
+import { getGpuSwitches } from "./gpuSwitches";
 
 describe("getGpuSwitches", () => {
 	it("returns the Linux VAAPI workaround without forcing EGL on Wayland", () => {
@@ -53,14 +10,18 @@ describe("getGpuSwitches", () => {
 				WAYLAND_DISPLAY: "wayland-0",
 			}),
 		).toEqual({
-			useGl: undefined,
 			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
 		});
 	});
 
 	it("returns the X11 EGL workaround on Linux X11", () => {
 		expect(getGpuSwitches("linux", { XDG_SESSION_TYPE: "x11" })).toEqual({
-			useGl: "egl",
+			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
+		});
+	});
+
+	it("does not force a GL implementation when the session type is unknown", () => {
+		expect(getGpuSwitches("linux", {})).toEqual({
 			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
 		});
 	});

--- a/electron/gpuSwitches.ts
+++ b/electron/gpuSwitches.ts
@@ -4,45 +4,9 @@ export interface GpuSwitches {
 	disableFeatures?: string[];
 }
 
-function normalizeLinuxWindowSystem(value: string | undefined): "wayland" | "x11" | null {
-	const normalized = value?.trim().toLowerCase();
-	if (normalized === "wayland" || normalized === "x11") {
-		return normalized;
-	}
-
-	return null;
-}
-
-function getForcedLinuxWindowSystem(env: NodeJS.ProcessEnv): "wayland" | "x11" | null {
-	return (
-		normalizeLinuxWindowSystem(env.OZONE_PLATFORM) ??
-		normalizeLinuxWindowSystem(env.ELECTRON_OZONE_PLATFORM_HINT)
-	);
-}
-
-export function shouldForceLinuxEgl(env: NodeJS.ProcessEnv): boolean {
-	const forcedWindowSystem = getForcedLinuxWindowSystem(env);
-	if (forcedWindowSystem === "wayland") {
-		return false;
-	}
-	if (forcedWindowSystem === "x11") {
-		return true;
-	}
-
-	const sessionType = env.XDG_SESSION_TYPE?.toLowerCase();
-	if (sessionType === "wayland") {
-		return false;
-	}
-	if (sessionType === "x11") {
-		return true;
-	}
-
-	return !env.WAYLAND_DISPLAY;
-}
-
 export function getGpuSwitches(
 	platform: NodeJS.Platform,
-	env: NodeJS.ProcessEnv = process.env,
+	_env: NodeJS.ProcessEnv = process.env,
 ): GpuSwitches {
 	if (platform === "darwin") {
 		return {
@@ -56,8 +20,9 @@ export function getGpuSwitches(
 	}
 
 	if (platform === "linux") {
+		// No use-gl override: Chromium only allows (gl=egl-angle, angle=default) on Linux now.
+		// Passing use-gl=egl requests (gl=egl-gles2, angle=none) and kills the GPU process.
 		return {
-			useGl: shouldForceLinuxEgl(env) ? "egl" : undefined,
 			disableFeatures: ["VaapiVideoDecoder", "VaapiVideoEncoder"],
 		};
 	}

--- a/electron/gpuSwitches.ts
+++ b/electron/gpuSwitches.ts
@@ -1,6 +1,5 @@
 export interface GpuSwitches {
 	useAngle?: string;
-	useGl?: string;
 	disableFeatures?: string[];
 }
 

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -89,13 +89,11 @@ app.on("web-contents-created", (_event, contents) => {
 });
 
 function configureGpuAccelerationSwitches() {
-	const { useAngle, useGl, disableFeatures } = getGpuSwitches(process.platform, process.env);
+	const { useAngle, disableFeatures } = getGpuSwitches(process.platform, process.env);
 	if (useAngle) {
 		app.commandLine.appendSwitch("use-angle", useAngle);
 	}
-	if (useGl) {
-		app.commandLine.appendSwitch("use-gl", useGl);
-	}
+
 	if (disableFeatures && disableFeatures.length > 0) {
 		app.commandLine.appendSwitch("disable-features", disableFeatures.join(","));
 	}


### PR DESCRIPTION
# Pull Request Template

## Description

Removes the `--use-gl=egl` switch that Recordly appends on Linux X11 sessions. The switch requests a
GL implementation that Chromium rejects, so the GPU process exits on every launch and the app
restart-loops into software rendering. Dropping the override lets Linux resolve to Chromium's allowed
default — the same path the Wayland branch already took.

This is **PR 1 of 4** in a series fixing Recordly on Ubuntu 24.04. The four are independent, touch
disjoint files, and can be reviewed and merged separately:

| # | PR | Area | Issues |
|---|----|------|--------|
| **1** | **Stop forcing EGL (this PR)** | `electron/gpuSwitches.*` | #364, #441 |
| 2 | Real X11 screen source instead of the portal sentinel | `src/hooks/useScreenRecorder.ts` | #137, #364, #441 |
| 3 | Default Lightning render backend to WebGL | `src/lib/exporter/modernVideoExporter.ts` | #644 |
| 4 | Re-land HUD menu expand | `electron/windows.ts`, `electron/hudOverlayBounds.*` | re-lands #612 |

This one comes first because it is the enabler: until the GPU process stays up, reviewers on Linux
cannot meaningfully test the other three.

## Motivation

`electron/main.ts` calls `app.commandLine.appendSwitch("use-gl", "egl")` whenever `getGpuSwitches()`
returns `useGl: "egl"`, which the old `shouldForceLinuxEgl()` did for every non-Wayland session.
`--use-gl=egl` resolves to `(gl=egl-gles2, angle=none)`. The GL factory in the bundled Electron 43
build does not allow that combination and exits the GPU process:

```
[ERROR:ui/gl/init/gl_factory.cc:102] Requested GL implementation (gl=egl-gles2,angle=none)
not found in allowed implementations: [(gl=egl-angle,angle=default)].
[ERROR:components/viz/service/main/viz_main_impl.cc:189] Exiting GPU process due to errors
during initialization
```

This repeats for each spawned subprocess. The app still starts and the media server binds, but the
GPU process keeps failing and restarting, and rendering falls back to software. The affected surface
is the editor preview and export, which use PixiJS/WebGL for compositing.

Two consequences worth calling out:

- **It overrides user-supplied flags.** `appendSwitch` runs after Chromium parses argv, and Chromium
  reads the last value of a switch. So `--use-gl` / `--use-angle` / `--gl` passed on the command line
  are silently overridden. That is why every CLI workaround fails and only `--disable-gpu` works —
  which is exactly the "fix" being passed around for this app today.
- **Wayland was already fine.** `shouldForceLinuxEgl()` returned `false` on Wayland, so that branch
  passed `useGl: undefined` and resolved to the allowed `egl-angle` default. This change gives X11 the
  same treatment rather than inventing a new path.

Git history does not record why EGL was forced on X11 — `gpuSwitches.ts` was created already
containing it (`be8c5ef`), most likely a GLX-era NVIDIA workaround. Modern ANGLE defaults to EGL on
Linux regardless.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [x] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

<sub>Bug fix in substance; the cleanup checkbox covers removal of the now-unreachable
`shouldForceLinuxEgl()` helpers and the dead `useGl` plumbing they fed.</sub>

## Related Issue(s)

Refs #364, #441 — the GL half of both.

## Screenshots / Video

Not applicable — this fix has no UI surface. The observable change is in the GPU process lifecycle,
so before/after logs are the meaningful artifact.

**Before** (X11, `--use-gl=egl` appended by the app):

```
[ERROR:ui/gl/init/gl_factory.cc:102] Requested GL implementation (gl=egl-gles2,angle=none)
not found in allowed implementations: [(gl=egl-angle,angle=default)].
[ERROR:components/viz/service/main/viz_main_impl.cc:189] Exiting GPU process due to errors
during initialization
```
…repeating per subprocess, GPU process restart-looping.

**After** (no override): clean start, no `gl_factory` error, GPU process stays up.

## Testing Guide

Unit tests:

```bash
npx vitest --run electron/gpuSwitches.test.ts
npx biome lint electron/gpuSwitches.ts electron/gpuSwitches.test.ts electron/main.ts
```

Manual, on a Linux X11 session:

```bash
npm run dev
```

Expected: no `Requested GL implementation ... not found in allowed implementations` error, no GPU
process restart loop, and no need for `--disable-gpu`.

To reproduce the original failure on the same machine, re-add the switch (or launch a pre-fix build
with `--use-gl=egl`) and watch the GPU process exit on startup.

**Verified on:** Razer Blade 15 Base (2021), Intel i7-10750H + NVIDIA RTX 3070 Laptop (hybrid,
PRIME `on-demand`), Ubuntu 24.04 LTS, kernel 6.17.0-35, NVIDIA driver 580, X11 session.

- With `--use-gl=egl`: reproduces the error above verbatim; GPU process exits.
- Without it: clean start, no GL errors, GPU process stays up.

Wayland behaviour is unchanged — it already passed `useGl: undefined` and resolved to the same
allowed default.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

## Notes

Investigated and drafted with Claude Code. The failure logs and the A/B below are from real
runs on the hardware listed, not generated — I can re-run either on request.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Removed forced EGL/GL selection on Linux so the app now uses the platform default graphics behavior.
  - Kept Linux-specific GPU workarounds active where applicable (including VAAPI-related feature disabling).
  - Updated GPU acceleration switch handling to apply only the relevant options, avoiding unnecessary graphics overrides.
- **Tests**
  - Updated the GPU switch selection test coverage to match the new Linux behavior and verify the absence of GL forcing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->