### PR TITLE
CRITICAL- fix: correct GitHub publish owner

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -41,7 +41,7 @@
   "publish": [
     {
       "provider": "github",
-      "owner": "webadderall",
+      "owner": "webadderallorg",
       "repo": "Recordly",
       "tagNamePrefix": "v",
       "publishAutoUpdate": true


### PR DESCRIPTION
# Pull Request Template

## Description
Correct the GitHub publish owner in electron-builder.json5 from webadderall to webadderallorg.

## Motivation
The upstream Recordly repository is hosted at webadderallorg/Recordly, but the electron-builder GitHub publishing configuration referenced webadderall as the owner.

This could cause release publishing to target the wrong GitHub repository.

## Type of Change
Bug fix

## Related Issue(s)
None

## Testing Guide
Verify the upstream repository is webadderallorg/Recordly.
Verify electron-builder.json5 contains:
"owner": "webadderallorg".
Review the PR diff to confirm that only the GitHub publish owner was changed.

## Checklist
- [x] I have performed a self-review of my code.

---
*Thank you for contributing!*



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application publishing configuration to use the new repository owner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->