### PR TITLE
Fix HUD overlay blocking the screen while recording

### DIFF
--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -182,9 +182,16 @@ function getHudOverlayBounds() {
 		recordingActive: hudOverlayRecordingActive,
 		webcamPreviewVisible: hudOverlayWebcamPreviewVisible,
 	});
+	// The fallback geometry is a fixed, solid block sized for platforms that
+	// cannot make the overlay click-through.  Using it while recording on a
+	// platform that *can* pass clicks through leaves a large real window sitting
+	// over the screen: the OS window picker (Cmd+Shift+5) highlights and selects
+	// the HUD instead of the app behind it, and any moment the renderer holds the
+	// mouse the whole block swallows clicks.  Passthrough support is a property
+	// of the platform, not of whether a recording is in progress.
 	return getHudOverlayWindowBounds(
 		workArea,
-		isHudOverlayMousePassthroughSupported() && !hudOverlayRecordingActive,
+		isHudOverlayMousePassthroughSupported(),
 		fallbackExpanded,
 	);
 }


### PR DESCRIPTION
## Problem

While a recording is active, the HUD overlay becomes a large, real window sitting over the screen. In practice this means:

- The macOS window picker (<kbd>Cmd</kbd>+<kbd>Shift</kbd>+<kbd>5</kbd>) highlights and selects the **HUD** instead of the window behind it, so that region of the screen can't be captured while recording.
- Any moment the renderer legitimately holds the mouse (hovering the bar or the webcam preview), the entire block swallows clicks rather than just the visible controls — the app being recorded becomes unreachable behind it.
- The floating webcam preview can only be dragged within that block, since it's positioned by a CSS transform inside the overlay window.

## Cause

`getHudOverlayBounds()` passed this as the "passthrough supported" argument:

```ts
isHudOverlayMousePassthroughSupported() && !hudOverlayRecordingActive
```

On macOS and Windows that evaluates to `false` **during recording**, so the HUD is handed the *fallback* geometry — a fixed 860×540 (or 160px compact) block intended for platforms that cannot make the overlay click-through at all.

Meanwhile `setHudOverlayMousePassthrough()` uses the real platform check, so the window ends up with fallback bounds but passthrough-style mouse handling. The two paths disagree about which mode the overlay is in.

## Fix

Whether the overlay can pass clicks through is a property of the **platform**, not of whether a recording is in progress — so use the platform check alone.

Platforms without passthrough support (Linux) keep the fallback geometry exactly as before. This only changes the recording case on platforms that already use a click-through overlay when idle.

## Verification

`npm test` — 1022 tests pass. `tsc --noEmit` and `biome check` clean.

Verified on macOS 15 (arm64) with a packaged build by instrumenting the overlay window and logging its real state every 500ms during an active recording:

| | before | after |
|---|---|---|
| bounds while recording | 860×540 block | `1710×997` (full work area) |
| `setIgnoreMouseEvents` | — | `true` in 168 / 204 samples |

The 36 samples with passthrough off all correspond to the pointer being over the bar or the webcam preview, which is the intended behaviour. Manually confirmed afterwards that the screen behind the HUD is clickable during a recording and the webcam preview can be dragged anywhere on screen.

I couldn't reproduce on Windows or Linux — the code path is shared with macOS on Windows, and Linux is unaffected by construction, but a second pair of eyes on Windows would be welcome.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HUD overlay positioning on platforms without mouse-passthrough support.
  * Ensured fallback window geometry is used consistently, including while recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->