### PR TITLE
fix(webcam): stop the floating preview vanishing when dragged to an edge

### DIFF
--- a/src/components/launch/floatingWebcamPreview.test.ts
+++ b/src/components/launch/floatingWebcamPreview.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, it } from "vitest";
 import {
 	canShowFloatingWebcamPreview,
 	canToggleFloatingWebcamPreview,
+	clampPreviewPosition,
+	resolvePreviewViewport,
 } from "./floatingWebcamPreview";
 
 describe("canShowFloatingWebcamPreview", () => {
@@ -22,5 +24,53 @@ describe("canToggleFloatingWebcamPreview", () => {
 
 	it("hides the toggle when the platform cannot support the floating preview", () => {
 		expect(canToggleFloatingWebcamPreview(false)).toBe(false);
+	});
+});
+
+describe("resolvePreviewViewport", () => {
+	it("uses the window viewport, not the display, so the preview cannot leave its window", () => {
+		// HUD overlay covers the work area: shorter than the display because of
+		// the menu bar and Dock. Clamping to screen.height let the preview be
+		// dragged below the window's bottom edge, where it clipped and vanished.
+		expect(
+			resolvePreviewViewport({ width: 1512, height: 916 }, { width: 1512, height: 982 }),
+		).toEqual({ width: 1512, height: 916 });
+	});
+
+	it("falls back to the display only for a degenerate zero viewport", () => {
+		expect(resolvePreviewViewport({ width: 0, height: 0 }, { width: 1512, height: 982 })).toEqual({
+			width: 1512,
+			height: 982,
+		});
+		expect(resolvePreviewViewport({ width: 0, height: 0 }, null)).toEqual({ width: 0, height: 0 });
+	});
+});
+
+describe("clampPreviewPosition", () => {
+	const preview = { width: 240, height: 240 };
+	const viewport = { width: 1512, height: 916 };
+
+	it("keeps the preview fully inside the viewport", () => {
+		expect(clampPreviewPosition({ left: 4000, top: 4000 }, preview, viewport)).toEqual({
+			left: 1272,
+			top: 676,
+		});
+		expect(clampPreviewPosition({ left: -500, top: -500 }, preview, viewport)).toEqual({
+			left: 0,
+			top: 0,
+		});
+	});
+
+	it("leaves an in-bounds position untouched", () => {
+		expect(clampPreviewPosition({ left: 100, top: 100 }, preview, viewport)).toEqual({
+			left: 100,
+			top: 100,
+		});
+	});
+
+	it("pins to the origin when the preview is larger than the viewport", () => {
+		expect(
+			clampPreviewPosition({ left: 50, top: 50 }, { width: 300, height: 300 }, { width: 200, height: 200 }),
+		).toEqual({ left: 0, top: 0 });
 	});
 });

--- a/src/components/launch/floatingWebcamPreview.ts
+++ b/src/components/launch/floatingWebcamPreview.ts
@@ -10,3 +10,39 @@ export function canToggleFloatingWebcamPreview(
 ): boolean {
 	return hudOverlayMousePassthroughSupported !== false;
 }
+
+export interface PreviewViewportSize {
+	width: number;
+	height: number;
+}
+
+/**
+ * Bounds the dragged preview must stay inside: the window that renders it, not
+ * the display. The HUD overlay covers the work area (menu bar and Dock
+ * excluded), so the screen size overshoots the window's bottom edge — dragging
+ * the preview into that band moves it outside the window, where it clips and
+ * disappears. The screen is only a fallback for a degenerate zero viewport.
+ */
+export function resolvePreviewViewport(
+	inner: PreviewViewportSize,
+	screen?: PreviewViewportSize | null,
+): PreviewViewportSize {
+	return {
+		width: inner.width > 0 ? inner.width : (screen?.width ?? 0),
+		height: inner.height > 0 ? inner.height : (screen?.height ?? 0),
+	};
+}
+
+/** Keeps the preview fully inside `viewport`, so it can never be dragged out of sight. */
+export function clampPreviewPosition(
+	position: { left: number; top: number },
+	previewSize: PreviewViewportSize,
+	viewport: PreviewViewportSize,
+): { left: number; top: number } {
+	const clamp = (value: number, max: number) => Math.min(Math.max(0, value), Math.max(0, max));
+
+	return {
+		left: clamp(position.left, viewport.width - previewSize.width),
+		top: clamp(position.top, viewport.height - previewSize.height),
+	};
+}

--- a/src/components/launch/hooks/useWebcamPreviewOverlay.ts
+++ b/src/components/launch/hooks/useWebcamPreviewOverlay.ts
@@ -1,5 +1,9 @@
 import { useCallback, useEffect, useRef, useState, type PointerEvent } from "react";
-import { canShowFloatingWebcamPreview } from "../floatingWebcamPreview";
+import {
+	canShowFloatingWebcamPreview,
+	clampPreviewPosition,
+	resolvePreviewViewport,
+} from "../floatingWebcamPreview";
 
 const WEBCAM_PREVIEW_DRAG_THRESHOLD = 6;
 const DEFAULT_WEBCAM_PREVIEW_OFFSET = { x: 0, y: 0 };
@@ -118,17 +122,17 @@ export function useWebcamPreviewOverlay({
 
 			const latestDeltaX = pointer.clientX - latestDragState.startX;
 			const latestDeltaY = pointer.clientY - latestDragState.startY;
-			const viewportWidth = Math.max(window.innerWidth, window.screen?.width ?? 0);
-			const viewportHeight = Math.max(window.innerHeight, window.screen?.height ?? 0);
-			const unclampedLeft = latestDragState.initialLeft + latestDeltaX;
-			const unclampedTop = latestDragState.initialTop + latestDeltaY;
-			const clampedLeft = Math.min(
-				Math.max(0, unclampedLeft),
-				Math.max(0, viewportWidth - latestDragState.previewWidth),
+			const viewport = resolvePreviewViewport(
+				{ width: window.innerWidth, height: window.innerHeight },
+				window.screen ? { width: window.screen.width, height: window.screen.height } : null,
 			);
-			const clampedTop = Math.min(
-				Math.max(0, unclampedTop),
-				Math.max(0, viewportHeight - latestDragState.previewHeight),
+			const { left: clampedLeft, top: clampedTop } = clampPreviewPosition(
+				{
+					left: latestDragState.initialLeft + latestDeltaX,
+					top: latestDragState.initialTop + latestDeltaY,
+				},
+				{ width: latestDragState.previewWidth, height: latestDragState.previewHeight },
+				viewport,
 			);
 
 			const nextOffset = {


### PR DESCRIPTION
## The bug

Dragging the floating webcam preview toward an edge makes it disappear, with no way to bring it back short of toggling the preview off and on.

## Cause

The drag clamp in `useWebcamPreviewOverlay.ts` bounds the preview by the larger of the window viewport and the display:

```ts
const viewportWidth = Math.max(window.innerWidth, window.screen?.width ?? 0);
const viewportHeight = Math.max(window.innerHeight, window.screen?.height ?? 0);
```

The HUD overlay window covers the work area, which excludes the menu bar and Dock, so `screen.height` sits below the window's own bottom edge. Dragging into that band moves the preview outside the window that renders it, where it clips and vanishes. On a 1512x982 display with a 916px-tall work area, that leaves a 66px band where the preview is gone.

## Fix

Clamp to the window's own viewport, falling back to the display only when `innerWidth`/`innerHeight` reads zero, which is what the `Math.max` appears to have been guarding against.

`resolvePreviewViewport` and `clampPreviewPosition` are pulled out as pure helpers so the behaviour can be tested directly, following the same pattern as `hudOverlayBounds.ts` and `hudViewportBounds.ts`.

## Tests

Five cases added to `floatingWebcamPreview.test.ts`, including the regression itself: a 916px work area inside a 982px display must clamp to 916. Existing tests still pass (17 total in `src/components/launch/`).

## Scope

This keeps the preview inside the Recordly window. It does not add free positioning across the desktop, which would need the preview promoted to its own always-on-top window, and would also cover #683.

Tested on macOS 15.1 (24B83), Apple Silicon.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webcam preview positioning during dragging to keep the preview fully within the visible viewport.
  * Added fallback handling for unavailable or zero-sized window dimensions.
  * Ensured oversized previews remain pinned to the viewport origin when necessary.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->