### PR TITLE
test: guard HUD click-through surface

### DIFF
--- a/src/components/launch/hudPointerSurface.test.ts
+++ b/src/components/launch/hudPointerSurface.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import ts from "typescript";
+import { describe, expect, it } from "vitest";
+
+const launchWindowSource = readFileSync(new URL("./LaunchWindow.tsx", import.meta.url), "utf8");
+const sourceFile = ts.createSourceFile(
+	"LaunchWindow.tsx",
+	launchWindowSource,
+	ts.ScriptTarget.Latest,
+	true,
+	ts.ScriptKind.TSX,
+);
+
+function findElementByRef(refName: string): ts.JsxElement {
+	let match: ts.JsxElement | undefined;
+
+	function visit(node: ts.Node) {
+		if (match) return;
+
+		if (ts.isJsxOpeningElement(node)) {
+			const ref = node.attributes.properties.find(
+				(attribute): attribute is ts.JsxAttribute =>
+					ts.isJsxAttribute(attribute) &&
+					attribute.name.getText(sourceFile) === "ref" &&
+					attribute.initializer?.getText(sourceFile) === `{${refName}}`,
+			);
+			if (ref && ts.isJsxElement(node.parent)) {
+				match = node.parent;
+				return;
+			}
+		}
+
+		ts.forEachChild(node, visit);
+	}
+
+	visit(sourceFile);
+	if (!match) throw new Error(`Could not find JSX element with ref ${refName}`);
+	return match;
+}
+
+function getAttributeNames(element: ts.JsxElement): string[] {
+	return element.openingElement.attributes.properties.flatMap((attribute) =>
+		ts.isJsxAttribute(attribute) ? [attribute.name.getText(sourceFile)] : [],
+	);
+}
+
+function getClassNameSource(element: ts.JsxElement): string {
+	const className = element.openingElement.attributes.properties.find(
+		(attribute): attribute is ts.JsxAttribute =>
+			ts.isJsxAttribute(attribute) && attribute.name.getText(sourceFile) === "className",
+	);
+	return className?.initializer?.getText(sourceFile) ?? "";
+}
+
+describe("HUD pointer surface", () => {
+	it("keeps the stationary layout wrapper click-through after the HUD moves", () => {
+		const transformElement = findElementByRef("hudBarTransformRef");
+		const layoutWrapper = transformElement.parent;
+
+		expect(ts.isJsxElement(layoutWrapper)).toBe(true);
+		if (!ts.isJsxElement(layoutWrapper)) return;
+
+		expect(getClassNameSource(layoutWrapper)).toContain("pointer-events-none");
+		expect(getClassNameSource(layoutWrapper)).not.toContain("pointer-events-auto");
+		expect(getAttributeNames(layoutWrapper)).not.toContain("onMouseEnter");
+		expect(getAttributeNames(layoutWrapper)).not.toContain("onMouseLeave");
+	});
+
+	it("makes the visibly transformed HUD bar interactive", () => {
+		const hudBar = findElementByRef("hudBarRef");
+
+		expect(getClassNameSource(hudBar)).toContain("pointer-events-auto");
+		expect(getAttributeNames(hudBar)).toContain("onMouseEnter");
+		expect(getAttributeNames(hudBar)).toContain("onMouseLeave");
+	});
+});


### PR DESCRIPTION
## Description

Adds a focused regression test for the floating recording HUD's pointer surface. The test parses `LaunchWindow.tsx` and verifies that:

- the stationary layout wrapper remains click-through after the HUD is moved
- only the visibly transformed HUD bar is interactive
- the hover handlers stay on that visible bar

## Motivation

This protects the fix for the dead click zone reported in #698. The failure occurred when the interactive pointer surface stayed at the HUD's original bottom-screen position while the visible pill was translated elsewhere.

The production-side fix is already present on `main`; this PR adds the missing regression coverage so that layout refactors cannot silently restore the invisible click-blocking region.

## Type of Change

- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [x] Other: regression test

## Related Issue(s)

Related to #698.

## Screenshots / Video

Not applicable; this is a test-only change.

Manual macOS verification was also performed: the issue was reproduced on v1.3.3, then an app containing the current click-through fixes was tested successfully. After moving the HUD, the original bottom-screen area accepted clicks normally.

## Testing Guide

- `npm test` — 118 test files, 1,054 tests passed
- `npm exec tsc -- --noEmit`
- `npm exec tsc -- --noEmit --strict --target ES2020 --module ESNext --moduleResolution bundler --skipLibCheck src/components/launch/hudPointerSurface.test.ts`
- `npx biome check src/components/launch/hudPointerSurface.test.ts`
- `CSC_IDENTITY_AUTO_DISCOVERY=false npm run build`

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added regression coverage for the reported behavior.
- [x] I have linked the related issue.
- [x] No changelog update is needed for this test-only PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify correct pointer interaction behavior for the launch HUD.
  * Confirmed stationary layout elements remain non-interactive while the transformed HUD bar supports hover interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->