### PR TITLE
docs: clarify extension system status and remove stale examples (#862)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,8 +5,12 @@ Thank you for considering contributing to this project! By contributing, you hel
 Areas where help is especially valuable:
 - Export optimisations
 - Native screen recording for Linux
-- Wallpaper submissions
-- Extensions (device frames, click effects, render hooks — see [EXTENSIONS.md](./EXTENSIONS.md))
+- Wallpaper submissions (see [src/lib/wallpapers.ts](./src/lib/wallpapers.ts))
+- Windows and macOS recording reliability
+- Translations and localisations
+
+> [!NOTE]
+> Extension and custom render hook contributions are currently paused while core recording and rendering pipelines are being streamlined. See [EXTENSIONS.md](./EXTENSIONS.md) for details.
 
 ## How to Contribute
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -4,11 +4,7 @@
 > **Status: Extension System Inactive**
 > Following the core architecture cleanup in PR #844, runtime extension loading, custom render hooks, and marketplace access are currently disabled in Recordly 1.3.5+. The in-app Extensions panel currently acts as an informational placeholder.
 >
-> This document is preserved as an architectural reference and design specification for future extension/plugin system rework. Example extension bundles (`extension-examples/`) are not currently packaged in the repository. If you are looking to contribute custom wallpapers or cursors, please submit them directly as built-in assets in `src/lib/wallpapers.ts` or `src/assets/cursors/`.
-
-Go to https://www.marketplace.recordly.dev/extensions for full, regularly updated documentation
-
-Recordly extensions run in the editor renderer and use a permission-gated host API. They can draw into the render pipeline, react to playback and export events, register cursor effects, add settings panels, and contribute packaged assets such as frames, wallpapers, and cursor styles.
+> This document is preserved as an architectural reference and design specification for future extension/plugin system rework. If you are looking to contribute custom wallpapers or cursors, please submit them directly as built-in assets in `src/lib/wallpapers.ts` or `src/assets/cursors/`.
 
 ## Architectural Overview
 

--- a/EXTENSIONS.md
+++ b/EXTENSIONS.md
@@ -1,12 +1,18 @@
 # Recordly Extension API
 
+> [!NOTE]
+> **Status: Extension System Inactive**
+> Following the core architecture cleanup in PR #844, runtime extension loading, custom render hooks, and marketplace access are currently disabled in Recordly 1.3.5+. The in-app Extensions panel currently acts as an informational placeholder.
+>
+> This document is preserved as an architectural reference and design specification for future extension/plugin system rework. Example extension bundles (`extension-examples/`) are not currently packaged in the repository. If you are looking to contribute custom wallpapers or cursors, please submit them directly as built-in assets in `src/lib/wallpapers.ts` or `src/assets/cursors/`.
+
 Go to https://www.marketplace.recordly.dev/extensions for full, regularly updated documentation
 
 Recordly extensions run in the editor renderer and use a permission-gated host API. They can draw into the render pipeline, react to playback and export events, register cursor effects, add settings panels, and contribute packaged assets such as frames, wallpapers, and cursor styles.
 
-## Quick Start
+## Architectural Overview
 
-For local user-installed extensions, use `Extensions -> Open Directory` in the app. Recordly stores them in the app `userData/extensions` directory. This repo also includes installable example bundles under `extension-examples/`.
+Historically, user-installed extensions were stored in the app's `userData/extensions` directory (`Extensions -> Open Directory`). The specification below outlines the manifest format and permissions model intended for extensions when the subsystem is active.
 
 ### Minimum Extension
 
@@ -305,6 +311,8 @@ Use `parentSection` to nest your panel inside an existing area such as `cursor` 
 3. Runtime: Registered callbacks execute in preview and export according to their phase.
 4. Deactivation: `deactivate()` runs and all registrations are automatically disposed.
 
-## Examples
+## Built-in Assets vs Extensions
 
-- `extension-examples/webadderall.more-wallpapers` shows a user-installable wallpaper bundle that registers 180 packaged wallpapers through `registerWallpaper()`.
+While runtime extension bundles are disabled, custom wallpapers and cursor styles can be contributed directly to the core application:
+- Built-in wallpapers: [src/lib/wallpapers.ts](./src/lib/wallpapers.ts)
+- Built-in cursors: [src/assets/cursors/](./src/assets/cursors/)


### PR DESCRIPTION
## Description
Following the core architecture cleanup in #844, this PR synchronizes `CONTRIBUTING.md` and `EXTENSIONS.md` with the current codebase:
- Adds a status alert banner to `EXTENSIONS.md` clarifying that runtime extension loading, render hooks, and marketplace access are disabled in 1.3.5+.
- Removes references to the non-existent `extension-examples/` directory.
- Updates `CONTRIBUTING.md` to point contributors toward active priorities (export optimizations, platform recording reliability, wallpapers, and translations) rather than paused extension APIs.
- Directs wallpaper and cursor contributors to built-in assets (`src/lib/wallpapers.ts` and `src/assets/cursors/`).

## Motivation
Resolves #862. The documentation previously pointed contributors to deleted extension APIs and a missing `extension-examples/` directory, causing confusion for new contributors.

## Type of Change
- [ ] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [x] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Resolves #862

## Screenshots / Video
N/A (documentation only)

## Testing Guide
- Inspected markdown files to ensure no broken relative links or lingering references to `extension-examples/`.
- Verified locale parity via `npm run i18n:check`.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance with wallpaper submission links and opportunities involving recording reliability and translations.
  * Clarified that extension and custom render hook contributions are currently paused.
  * Documented that runtime extensions, custom render hooks, and marketplace access are disabled in Recordly 1.3.5 and later.
  * Added architectural context for extensions and guidance on contributing built-in wallpapers and cursors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->