### PR TITLE
test(hud): guard full-screen passthrough bounds while recording

### DIFF
--- a/electron/hudOverlayRecordingBounds.test.ts
+++ b/electron/hudOverlayRecordingBounds.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// A recording-sized work area keeps the expected bounds easy to read: the
+// compact fallback window is 860x160 anchored to the bottom centre, while the
+// passthrough overlay covers the whole work area.
+const WORK_AREA = { x: 0, y: 0, width: 1920, height: 1080 };
+
+const setBounds = vi.fn();
+
+const electronScreen = {
+	getPrimaryDisplay: () => ({ workArea: WORK_AREA }),
+	getDisplayMatching: () => ({ workArea: WORK_AREA }),
+	getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+	on: vi.fn(),
+	off: vi.fn(),
+	removeListener: vi.fn(),
+};
+
+// windows.ts reaches the screen module through createRequire("electron"), which
+// bypasses vi.mock("electron"), so the CJS require has to be mocked as well.
+vi.mock("node:module", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:module")>();
+	return {
+		...actual,
+		default: actual,
+		createRequire: () => (id: string) => {
+			if (id === "electron") {
+				return { screen: electronScreen };
+			}
+			return actual.createRequire(import.meta.url)(id);
+		},
+	};
+});
+
+vi.mock("electron", () => {
+	class FakeBrowserWindow {
+		webContents = { send: vi.fn(), on: vi.fn(), setWindowOpenHandler: vi.fn() };
+		isDestroyed = () => false;
+		isVisible = () => true;
+		getBounds = () => WORK_AREA;
+		setBounds = setBounds;
+		setIgnoreMouseEvents = vi.fn();
+		setContentProtection = vi.fn();
+		setAlwaysOnTop = vi.fn();
+		showInactive = vi.fn();
+		show = vi.fn();
+		moveTop = vi.fn();
+		once = vi.fn();
+		on = vi.fn();
+		loadURL = vi.fn();
+		loadFile = vi.fn();
+	}
+
+	return {
+		app: {
+			getPath: () => "/tmp/recordly-test",
+			isPackaged: false,
+			isReady: () => true,
+			whenReady: vi.fn(),
+			on: vi.fn(),
+		},
+		BrowserWindow: FakeBrowserWindow,
+		ipcMain: { on: vi.fn(), handle: vi.fn() },
+		screen: electronScreen,
+	};
+});
+
+describe("HUD overlay bounds while recording", () => {
+	beforeEach(() => {
+		vi.resetModules();
+		setBounds.mockClear();
+	});
+
+	// Regression guard for the overlay swallowing clicks during a recording.
+	// getHudOverlayBounds() used to pass
+	// `isHudOverlayMousePassthroughSupported() && !hudOverlayRecordingActive`,
+	// so starting a recording dropped the HUD to the opaque 860x160 fallback
+	// window. Every click inside that region hit the overlay instead of the app
+	// being recorded, and the HUD's own Stop button became unreachable once the
+	// renderer asked for passthrough.
+	// Linux has no mouse passthrough, so the compact fallback window is the
+	// expected behaviour there and this guard does not apply.
+	it.skipIf(process.platform === "linux")(
+		"keeps the full work area on passthrough platforms once recording starts",
+		async () => {
+			const windows = await import("./windows");
+
+			windows.createHudOverlayWindow();
+			setBounds.mockClear();
+
+			windows.setHudOverlayRecordingActive(true);
+
+			expect(setBounds).toHaveBeenCalled();
+			const appliedBounds = setBounds.mock.calls.at(-1)?.[0];
+			expect(appliedBounds).toEqual(WORK_AREA);
+		},
+	);
+});


### PR DESCRIPTION
## Problem

`getHudOverlayBounds()` used to pass `isHudOverlayMousePassthroughSupported() && !hudOverlayRecordingActive` to `getHudOverlayWindowBounds()`. The `&& !hudOverlayRecordingActive` term meant that starting a recording made the overlay behave as if passthrough were unsupported, so it dropped from the full-screen click-through overlay to the compact **860x160** fallback window.

That window is opaque to clicks. While recording it swallowed every click landing in the bottom-centre of the screen instead of passing it through to the app being recorded, and the HUD's own Stop button became unreachable once the renderer requested passthrough on hover.

On a 1536x816 work area the overlay became an opaque bar at `(338, 656)`, which matches the region users report as unclickable.

This is the Windows/macOS counterpart of the click-blocking behaviour described in #861 (which covers the Linux side, where passthrough is genuinely unsupported).

## Status on main

Already fixed: dd7af604 ("Keep the recording webcam movable and visible") removed the `&& !hudOverlayRecordingActive` term. That change was made while working on the recording webcam rather than as a deliberate fix for this, and **no test covers the decision**, so the regression can silently return.

It is still present in every published release — v1.3.3, v1.3.4-beta.1 and v1.3.5-beta.2 — so users on a download rather than `main` still hit it.

## What this PR adds

A regression test only. **No production code changes** — `electron/windows.ts` is untouched.

The test drives the real `createHudOverlayWindow()` and `setHudOverlayRecordingActive()` code paths with `electron` mocked, then asserts the bounds applied while recording still cover the full work area. It binds to the actual call site rather than re-implementing the predicate, so it fails if the old expression comes back.

`windows.ts` resolves the screen module through `createRequire("electron")`, which bypasses `vi.mock("electron")`, so `node:module` is mocked alongside it.

## Verification

- Fails with `&& !hudOverlayRecordingActive` restored: `expected { x: 530, y: 920, width: 860 } to deeply equal { x: 0, y: 0, width: 1920 }`
- Passes on current `main`
- Full suite green: 1064 passed, 1 skipped, 120 files
- `tsc --noEmit` clean, `biome check` clean
- Skipped on Linux, where passthrough is unsupported and the compact fallback is intended (keeps #861/#863 unaffected)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where starting a recording could cause the HUD overlay to resize incorrectly and block clicks in other areas of the screen.
  - The HUD overlay now maintains the correct work-area bounds during recording on supported platforms.

- **Tests**
  - Added coverage to help prevent regressions in HUD overlay sizing during recording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->