### PR TITLE
fix(macos): stop recording overlays stealing focus from the capture target

### DIFF
--- a/electron/hudOverlayFocus.test.ts
+++ b/electron/hudOverlayFocus.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const WORK_AREA = { x: 0, y: 0, width: 1920, height: 1080 };
+
+const show = vi.fn();
+const showInactive = vi.fn();
+const loadFinishedHandlers: Array<() => void> = [];
+
+const electronScreen = {
+	getPrimaryDisplay: () => ({
+		workArea: WORK_AREA,
+		workAreaSize: { width: WORK_AREA.width, height: WORK_AREA.height },
+		size: { width: WORK_AREA.width, height: WORK_AREA.height },
+	}),
+	getDisplayMatching: () => ({
+		workArea: WORK_AREA,
+		workAreaSize: { width: WORK_AREA.width, height: WORK_AREA.height },
+		size: { width: WORK_AREA.width, height: WORK_AREA.height },
+	}),
+	getCursorScreenPoint: () => ({ x: 0, y: 0 }),
+	on: vi.fn(),
+	off: vi.fn(),
+	removeListener: vi.fn(),
+};
+
+// windows.ts resolves the screen module through createRequire("electron"),
+// which bypasses vi.mock("electron"), so the CJS require is mocked too.
+vi.mock("node:module", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("node:module")>();
+	return {
+		...actual,
+		default: actual,
+		createRequire: () => (id: string) => {
+			if (id === "electron") {
+				return { screen: electronScreen };
+			}
+			return actual.createRequire(import.meta.url)(id);
+		},
+	};
+});
+
+vi.mock("electron", () => {
+	class FakeBrowserWindow {
+		webContents = {
+			send: vi.fn(),
+			setWindowOpenHandler: vi.fn(),
+			on: (event: string, handler: () => void) => {
+				if (event === "did-finish-load") {
+					loadFinishedHandlers.push(handler);
+				}
+			},
+		};
+		isDestroyed = () => false;
+		isVisible = () => true;
+		isMinimized = () => false;
+		getBounds = () => WORK_AREA;
+		setBounds = vi.fn();
+		setIgnoreMouseEvents = vi.fn();
+		setContentProtection = vi.fn();
+		setAlwaysOnTop = vi.fn();
+		setVisibleOnAllWorkspaces = vi.fn();
+		showInactive = showInactive;
+		show = show;
+		moveTop = vi.fn();
+		once = vi.fn();
+		on = vi.fn();
+		loadURL = vi.fn();
+		loadFile = vi.fn();
+	}
+
+	return {
+		app: {
+			getPath: () => "/tmp/recordly-test",
+			isPackaged: false,
+			isReady: () => true,
+			whenReady: vi.fn(),
+			on: vi.fn(),
+		},
+		BrowserWindow: FakeBrowserWindow,
+		ipcMain: { on: vi.fn(), handle: vi.fn() },
+		screen: electronScreen,
+	};
+});
+
+// Regression guard for #846. The HUD and the countdown are always-on-top
+// windows that appear as recording starts. show() activates the owning app, so
+// on macOS it pulled focus off the window the user picked for window capture,
+// leaving the target unclickable. Both must be presented without activating.
+describe("recording overlays do not steal focus", () => {
+	const realPlatform = process.platform;
+
+	beforeEach(() => {
+		vi.resetModules();
+		show.mockClear();
+		showInactive.mockClear();
+		loadFinishedHandlers.length = 0;
+		// The regression was macOS-only: Windows already took the showInactive()
+		// path, so the platform has to be forced for this to be a real guard.
+		Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+	});
+
+	afterEach(() => {
+		Object.defineProperty(process, "platform", {
+			value: realPlatform,
+			configurable: true,
+		});
+	});
+
+	it("shows the HUD overlay without activating it", async () => {
+		const windows = await import("./windows");
+		windows.createHudOverlayWindow();
+
+		for (const handler of loadFinishedHandlers) {
+			handler();
+		}
+		// The HUD defers its first show until the renderer signals readiness.
+		await vi.waitFor(() => expect(showInactive).toHaveBeenCalled(), { timeout: 3000 });
+
+		expect(show).not.toHaveBeenCalled();
+	});
+
+	it("shows the countdown window without activating it", async () => {
+		const windows = await import("./windows");
+		windows.createCountdownWindow();
+
+		expect(loadFinishedHandlers.length).toBeGreaterThan(0);
+		for (const handler of loadFinishedHandlers) {
+			handler();
+		}
+
+		expect(showInactive).toHaveBeenCalled();
+		expect(show).not.toHaveBeenCalled();
+	});
+});

--- a/electron/hudOverlayFocus.test.ts
+++ b/electron/hudOverlayFocus.test.ts
@@ -119,10 +119,11 @@ describe("recording overlays do not steal focus", () => {
 		expect(show).not.toHaveBeenCalled();
 	});
 
-	it("leaves the Linux show() path alone", async () => {
-		// showInactive() and moveTop() are unsupported on Wayland, so Linux keeps
-		// the pre-existing show() behaviour rather than gaining calls that would
-		// silently do nothing there.
+	// showInactive() and moveTop() are unsupported on Wayland, so Linux keeps the
+	// pre-existing show() behaviour rather than gaining calls that would silently
+	// do nothing there. Both windows are covered: a regression in either one
+	// alone would otherwise go unnoticed.
+	it("leaves the Linux countdown show() path alone", async () => {
 		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
 
 		const windows = await import("./windows");
@@ -133,6 +134,21 @@ describe("recording overlays do not steal focus", () => {
 		}
 
 		expect(show).toHaveBeenCalled();
+		expect(showInactive).not.toHaveBeenCalled();
+	});
+
+	it("leaves the Linux HUD overlay show() path alone", async () => {
+		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+		const windows = await import("./windows");
+		windows.createHudOverlayWindow();
+
+		for (const handler of loadFinishedHandlers) {
+			handler();
+		}
+		// The HUD defers its first show until the renderer signals readiness.
+		await vi.waitFor(() => expect(show).toHaveBeenCalled(), { timeout: 3000 });
+
 		expect(showInactive).not.toHaveBeenCalled();
 	});
 

--- a/electron/hudOverlayFocus.test.ts
+++ b/electron/hudOverlayFocus.test.ts
@@ -119,6 +119,23 @@ describe("recording overlays do not steal focus", () => {
 		expect(show).not.toHaveBeenCalled();
 	});
 
+	it("leaves the Linux show() path alone", async () => {
+		// showInactive() and moveTop() are unsupported on Wayland, so Linux keeps
+		// the pre-existing show() behaviour rather than gaining calls that would
+		// silently do nothing there.
+		Object.defineProperty(process, "platform", { value: "linux", configurable: true });
+
+		const windows = await import("./windows");
+		windows.createCountdownWindow();
+
+		for (const handler of loadFinishedHandlers) {
+			handler();
+		}
+
+		expect(show).toHaveBeenCalled();
+		expect(showInactive).not.toHaveBeenCalled();
+	});
+
 	it("shows the countdown window without activating it", async () => {
 		const windows = await import("./windows");
 		windows.createCountdownWindow();

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -504,9 +504,14 @@ export function createHudOverlayWindow(): BrowserWindow {
 		// A focusable window is required for a Windows taskbar entry, but the
 		// always-on-top HUD must not steal focus when Recordly starts. show()
 		// activates the app, which on macOS pulls focus away from the window the
-		// user selected for capture, so present the HUD without activating it on
-		// every platform.
-		win.showInactive();
+		// user selected for capture, so present the HUD without activating it
+		// there too. Linux keeps show(): showInactive() is a no-op under Wayland,
+		// and the X11 overlay relies on the activation to appear reliably.
+		if (process.platform === "linux") {
+			win.show();
+		} else {
+			win.showInactive();
+		}
 		win.moveTop();
 		applyHudOverlayCaptureProtectionToWindow(win, hudOverlayHiddenFromCapture);
 		if (process.platform === "win32" && isHudOverlayMousePassthroughSupported()) {
@@ -1063,9 +1068,15 @@ export function createCountdownWindow(): BrowserWindow {
 	win.webContents.on("did-finish-load", () => {
 		if (!win.isDestroyed()) {
 			// The countdown sits above the capture target, so activating it would
-			// pull focus off that window right as recording starts.
-			win.showInactive();
-			win.moveTop();
+			// pull focus off that window right as recording starts. Linux keeps
+			// the previous show() path: showInactive()/moveTop() are unsupported
+			// under Wayland, so switching would change nothing there.
+			if (process.platform === "linux") {
+				win.show();
+			} else {
+				win.showInactive();
+				win.moveTop();
+			}
 		}
 	});
 

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -501,13 +501,12 @@ export function createHudOverlayWindow(): BrowserWindow {
 		// Showing or changing native window state can recreate platform window
 		// flags. Reassert capture protection on both sides of the transition.
 		applyHudOverlayCaptureProtectionToWindow(win, hudOverlayHiddenFromCapture);
-		if (process.platform === "win32") {
-			// A focusable window is required for a Windows taskbar entry, but the
-			// always-on-top HUD must not steal focus when Recordly starts.
-			win.showInactive();
-		} else {
-			win.show();
-		}
+		// A focusable window is required for a Windows taskbar entry, but the
+		// always-on-top HUD must not steal focus when Recordly starts. show()
+		// activates the app, which on macOS pulls focus away from the window the
+		// user selected for capture, so present the HUD without activating it on
+		// every platform.
+		win.showInactive();
 		win.moveTop();
 		applyHudOverlayCaptureProtectionToWindow(win, hudOverlayHiddenFromCapture);
 		if (process.platform === "win32" && isHudOverlayMousePassthroughSupported()) {
@@ -1063,12 +1062,10 @@ export function createCountdownWindow(): BrowserWindow {
 
 	win.webContents.on("did-finish-load", () => {
 		if (!win.isDestroyed()) {
-			if (process.platform === "win32") {
-				win.showInactive();
-				win.moveTop();
-			} else {
-				win.show();
-			}
+			// The countdown sits above the capture target, so activating it would
+			// pull focus off that window right as recording starts.
+			win.showInactive();
+			win.moveTop();
 		}
 	});
 


### PR DESCRIPTION
Fixes #846.

## Problem

Selecting a window for capture and starting a recording pulls focus back to Recordly. The target window loses focus and its controls stop responding, which breaks exactly the workflow window capture exists for — recording an interactive app.

Two always-on-top windows appear as recording starts, and both were shown with `show()`, which **activates the owning application**:

| Window | Location |
| --- | --- |
| HUD overlay | `createHudOverlayWindow()` |
| Countdown | `createCountdownWindow()` |

Both already had a `process.platform === "win32"` branch calling `showInactive()` instead. The countdown's was added in 92ee514f ("fix(recording): recover from fullscreen countdown failures"), and the HUD's carries the comment *"the always-on-top HUD must not steal focus when Recordly starts"*.

The non-Windows path was never given the same treatment. So on macOS both windows activate Recordly at the moment recording begins, moving focus off the capture target — matching the report: focus "stuck" on Recordly, buttons in the target window unresponsive.

## Fix

Use `showInactive()` on every platform and keep the existing `moveTop()` for z-order.

Neither window needs activation to be visible — both are `alwaysOnTop`, and the HUD is already presented without focus on Windows, so this makes macOS behave the way Windows already does rather than inventing new semantics.

The tray **"Show Controls"** path in `main.ts` is deliberately left unchanged: that is an explicit user request to bring the HUD forward, so focusing is correct there.

## Trade-off worth flagging

The countdown supports click and <kbd>Esc</kbd> to cancel, which needs keyboard focus. After this change macOS matches Windows, where `showInactive()` has meant <kbd>Esc</kbd>-to-cancel does not work since 92ee514f. Clicking the countdown still cancels, since that focuses it first.

I judged silently stealing focus from the capture target to be the worse bug, and consistency with Windows the safer default — but if you would rather keep <kbd>Esc</kbd> working on macOS, the countdown could keep `show()` while only the HUD changes. Happy to rework.

## Verification

- Regression test added for both windows
- The test forces `process.platform` to `"darwin"` — without that it passes against the unfixed code too, since CI/Windows already takes the `showInactive()` path. Confirmed it **fails** on the unfixed code (`expected "spy" to be called at least once`) and passes with the fix.
- Full suite green: 1065 passed, 1 skipped, 120 files
- `tsc --noEmit` clean, `biome check` clean

I do not have a macOS machine, so this is verified by code path and test rather than by reproducing on hardware. @rohan-prasen — if you are able to try a build from this branch, confirmation would be welcome.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - On macOS and other supported platforms, HUD overlays and countdown windows appear without activating or stealing focus from the active app.
  - On Linux, HUD overlays and countdown windows use standard display behavior, with countdown windows still moving to the front.

- **Tests**
  - Added coverage confirming platform-specific window display behavior, including non-activating overlays on macOS and standard display behavior on Linux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->