### PR TITLE
Fix Linux Wayland HUD oscillation on hover and popover menu clipping

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,15 +245,28 @@ o.window({ class = "^[Rr]ecordly$", float = true }, {
 })
 ```
 
-Plain `hyprland.conf` equivalent:
+Plain `hyprland.conf` equivalents:
+
+**Hyprland 0.53.0+ (new windowrule syntax):**
 
 ```ini
-windowrule = opacity 1 1, class:^[Rr]ecordly$
-windowrule = pin, class:^[Rr]ecordly$, floating:1
-windowrule = noblur, class:^[Rr]ecordly$, floating:1
-windowrule = noshadow, class:^[Rr]ecordly$, floating:1
-windowrule = nodim, class:^[Rr]ecordly$, floating:1
-windowrule = bordersize 0, class:^[Rr]ecordly$, floating:1
+windowrule = opacity 1 1, match:class ^[Rr]ecordly$
+windowrule = pin, match:class ^[Rr]ecordly$, match:float 1
+windowrule = noblur, match:class ^[Rr]ecordly$, match:float 1
+windowrule = noshadow, match:class ^[Rr]ecordly$, match:float 1
+windowrule = nodim, match:class ^[Rr]ecordly$, match:float 1
+windowrule = bordersize 0, match:class ^[Rr]ecordly$, match:float 1
+```
+
+**Hyprland < 0.53.0 (legacy windowrulev2 syntax):**
+
+```ini
+windowrulev2 = opacity 1 1, class:^[Rr]ecordly$
+windowrulev2 = pin, class:^[Rr]ecordly$, floating:1
+windowrulev2 = noblur, class:^[Rr]ecordly$, floating:1
+windowrulev2 = noshadow, class:^[Rr]ecordly$, floating:1
+windowrulev2 = nodim, class:^[Rr]ecordly$, floating:1
+windowrulev2 = bordersize 0, class:^[Rr]ecordly$, floating:1
 ```
 
 ## macOS: "App cannot be opened"

--- a/README.md
+++ b/README.md
@@ -225,6 +225,37 @@ Target-specific build commands are also available:
 
 ---
 
+## Linux: Hyprland / Omarchy
+
+Recordly's recording HUD, countdown, and source picker are transparent floating windows.
+Hyprland decorates them like any other window, so the compositor's blur, shadow, dim, and
+opacity rules show up as a grey box around the HUD. Wayland also ignores `alwaysOnTop`, so
+the HUD can end up behind other windows or stuck on one workspace.
+
+Add these rules to `~/.config/hypr/hyprland.lua` (Omarchy) and run `hyprctl reload`:
+
+```lua
+o.window("^[Rr]ecordly$", { tag = "-default-opacity", opacity = "1 1" })
+o.window({ class = "^[Rr]ecordly$", float = true }, {
+  pin = true,
+  no_blur = true,
+  no_shadow = true,
+  border_size = 0,
+  no_dim = true,
+})
+```
+
+Plain `hyprland.conf` equivalent:
+
+```ini
+windowrule = opacity 1 1, class:^[Rr]ecordly$
+windowrule = pin, class:^[Rr]ecordly$, floating:1
+windowrule = noblur, class:^[Rr]ecordly$, floating:1
+windowrule = noshadow, class:^[Rr]ecordly$, floating:1
+windowrule = nodim, class:^[Rr]ecordly$, floating:1
+windowrule = bordersize 0, class:^[Rr]ecordly$, floating:1
+```
+
 ## macOS: "App cannot be opened"
 
 Locally built apps may be quarantined by macOS.

--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -198,6 +198,7 @@ interface RendererNativeExportCapabilities {
 interface Window {
 	electronAPI: {
 		hudOverlaySetIgnoreMouse: (ignore: boolean) => void;
+		hudOverlaySetMenuOpen: (open: boolean) => void;
 		hudOverlaySetSourceSelectionActive: (active: boolean) => void;
 		hudOverlayDrag: (phase: "start" | "move" | "end", screenX: number, screenY: number) => void;
 		hudOverlayHide: () => void;
@@ -208,6 +209,7 @@ interface Window {
 		getHudOverlayMousePassthroughSupported: () => Promise<{
 			success: boolean;
 			supported: boolean;
+			resizeAnchor?: "bottom" | "center";
 		}>;
 		setHudOverlayCaptureProtection: (
 			enabled: boolean,

--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+	getHudOverlayResizeAnchor,
 	getHudOverlayWindowBounds,
 	resizeHudOverlayFallbackBounds,
 	shouldExpandHudOverlayFallback,
@@ -30,9 +31,9 @@ describe("getHudOverlayWindowBounds", () => {
 	it("expands the non-passthrough fallback for HUD menus and hover interaction", () => {
 		expect(getHudOverlayWindowBounds(workArea, false, true)).toEqual({
 			x: 650,
-			y: 540,
+			y: 400,
 			width: 860,
-			height: 540,
+			height: 680,
 		});
 	});
 
@@ -98,9 +99,9 @@ describe("resizeHudOverlayFallbackBounds", () => {
 			),
 		).toEqual({
 			x: 420,
-			y: 320,
+			y: 180,
 			width: 860,
-			height: 540,
+			height: 680,
 		});
 	});
 
@@ -110,9 +111,9 @@ describe("resizeHudOverlayFallbackBounds", () => {
 				workArea,
 				{
 					x: 420,
-					y: 320,
+					y: 180,
 					width: 860,
-					height: 540,
+					height: 680,
 				},
 				false,
 			),
@@ -138,10 +139,32 @@ describe("resizeHudOverlayFallbackBounds", () => {
 			),
 		).toEqual({
 			x: 1060,
-			y: 520,
+			y: 380,
 			width: 860,
-			height: 540,
+			height: 680,
 		});
+	});
+});
+
+describe("getHudOverlayResizeAnchor", () => {
+	it("returns bottom on non-linux platforms", () => {
+		expect(getHudOverlayResizeAnchor("darwin", {})).toBe("bottom");
+		expect(getHudOverlayResizeAnchor("win32", {})).toBe("bottom");
+	});
+
+	it("returns center on linux under wayland", () => {
+		expect(
+			getHudOverlayResizeAnchor("linux", { XDG_SESSION_TYPE: "wayland" }),
+		).toBe("center");
+		expect(
+			getHudOverlayResizeAnchor("linux", { WAYLAND_DISPLAY: "wayland-1" }),
+		).toBe("center");
+	});
+
+	it("returns bottom on linux under x11", () => {
+		expect(
+			getHudOverlayResizeAnchor("linux", { XDG_SESSION_TYPE: "x11" }),
+		).toBe("bottom");
 	});
 });
 

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -7,10 +7,25 @@ export interface HudOverlayWorkArea {
 
 const NON_PASSTHROUGH_HUD_WIDTH_DIP = 860;
 const NON_PASSTHROUGH_HUD_COMPACT_HEIGHT_DIP = 160;
-const NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP = 540;
+const NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP = 680;
 
 function clamp(value: number, min: number, max: number): number {
 	return Math.min(Math.max(value, min), max);
+}
+
+export type HudOverlayResizeAnchor = "bottom" | "center";
+
+// Wayland refuses client-side window placement, so the compositor decides where
+// a resized HUD lands. Hyprland keeps floating windows centered while X11 honors
+// the bottom-anchored bounds this module computes.
+export function getHudOverlayResizeAnchor(
+	platform: NodeJS.Platform,
+	env: NodeJS.ProcessEnv,
+): HudOverlayResizeAnchor {
+	if (platform !== "linux") {
+		return "bottom";
+	}
+	return env.XDG_SESSION_TYPE === "wayland" || env.WAYLAND_DISPLAY ? "center" : "bottom";
 }
 
 export function getHudOverlayWindowBounds(

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -167,6 +167,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	hudOverlaySetIgnoreMouse: (ignore: boolean) => {
 		ipcRenderer.send("hud-overlay-set-ignore-mouse", ignore);
 	},
+	hudOverlaySetMenuOpen: (open: boolean) => {
+		ipcRenderer.send("hud-overlay-set-menu-open", open);
+	},
 	hudOverlaySetSourceSelectionActive: (active: boolean) => {
 		ipcRenderer.send("hud-overlay-set-source-selection-active", active);
 	},

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -6,6 +6,7 @@ import { app, BrowserWindow, ipcMain } from "electron";
 import { supportsHudCaptureProtection } from "../src/lib/hudCaptureProtection";
 import { USER_DATA_PATH } from "./appPaths";
 import {
+	getHudOverlayResizeAnchor,
 	getHudOverlayWindowBounds,
 	resizeHudOverlayFallbackBounds,
 	shouldExpandHudOverlayFallback,
@@ -331,6 +332,14 @@ ipcMain.on("hud-overlay-set-ignore-mouse", (_event, ignore: boolean) => {
 	setHudOverlayMousePassthrough(Boolean(ignore));
 });
 
+// Linux has no hover-driven passthrough, so the compact HUD window only grows
+// while a menu is open; growing on hover moves the bar out from under the pointer.
+ipcMain.on("hud-overlay-set-menu-open", (_event, open: boolean) => {
+	if (process.platform === "linux") {
+		setHudOverlayFallbackExpanded(Boolean(open));
+	}
+});
+
 ipcMain.on("hud-overlay-set-source-selection-active", (_event, active: boolean) => {
 	hudOverlaySourceSelectionActive = Boolean(active);
 	if (hudOverlaySourceSelectionActive) {
@@ -418,6 +427,7 @@ ipcMain.handle("get-hud-overlay-mouse-passthrough-supported", () => {
 	return {
 		success: true,
 		supported: isHudOverlayMousePassthroughSupported(),
+		resizeAnchor: getHudOverlayResizeAnchor(process.platform, process.env),
 	};
 });
 

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -45,6 +45,19 @@ import { MarqueeText } from "./SourceSelector";
 
 const SHOW_DEV_UPDATE_PREVIEW = import.meta.env.DEV;
 
+// Wayland compositors (e.g. Hyprland) re-center resizing floating windows around their
+// midpoint rather than honoring bottom bounds.
+// In compact mode, the window is 160px tall with 20px (1.25rem / pb-5) bottom padding.
+// The distance from the window center (50vh = 80px) to the HUD bottom edge is:
+// 80px - 20px = 60px.
+// Setting paddingBottom to calc(50vh - 60px) maintains this constant 60px offset from
+// the window center, ensuring the HUD bar remains visually stationary on screen when
+// the window expands vertically to accommodate popover menus.
+const COMPACT_HUD_HEIGHT_DIP = 160;
+const STANDARD_HUD_BOTTOM_PADDING_PX = 20; // 1.25rem (pb-5)
+const WAYLAND_CENTER_OFFSET_PX =
+	COMPACT_HUD_HEIGHT_DIP / 2 - STANDARD_HUD_BOTTOM_PADDING_PX;
+
 export function LaunchWindow() {
 	return (
 		<LaunchPopoverCoordinatorProvider>
@@ -451,7 +464,9 @@ function LaunchWindowContent() {
 				style={{
 					height: "100vh",
 					paddingBottom:
-						hudOverlayResizeAnchor === "center" ? "calc(50vh - 60px)" : "1.25rem",
+						hudOverlayResizeAnchor === "center"
+							? `calc(50vh - ${WAYLAND_CENTER_OFFSET_PX}px)`
+							: "1.25rem",
 				}}
 			>
 				<div

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -109,6 +109,7 @@ function LaunchWindowContent() {
 
 	const {
 		hudOverlayMousePassthroughSupported,
+		hudOverlayResizeAnchor,
 		platform,
 		appVersion,
 		hideHudFromCapture,
@@ -446,8 +447,12 @@ function LaunchWindowContent() {
 			value={{ onMouseEnter: handleHudMouseEnter, onMouseLeave: handleHudMouseLeave }}
 		>
 			<div
-				className="w-full flex justify-center bg-transparent overflow-visible items-end pb-5 pointer-events-none"
-				style={{ height: "100vh" }}
+				className="w-full flex justify-center bg-transparent overflow-visible items-end pointer-events-none"
+				style={{
+					height: "100vh",
+					paddingBottom:
+						hudOverlayResizeAnchor === "center" ? "calc(50vh - 60px)" : "1.25rem",
+				}}
 			>
 				<div
 					ref={hudContentRef}

--- a/src/components/launch/hooks/useLaunchHudInteractionState.ts
+++ b/src/components/launch/hooks/useLaunchHudInteractionState.ts
@@ -1,4 +1,4 @@
-import { type MouseEvent, type RefObject, useCallback, useEffect, useRef } from "react";
+import { type MouseEvent, type RefObject, useCallback, useEffect, useLayoutEffect, useRef } from "react";
 
 export function useLaunchHudInteractionState({
 	openId,
@@ -15,7 +15,10 @@ export function useLaunchHudInteractionState({
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const popoverCloseTimeoutRef = useRef<NodeJS.Timeout | null>(null);
 	const openIdRef = useRef(openId);
-	openIdRef.current = openId;
+
+	useLayoutEffect(() => {
+		openIdRef.current = openId;
+	}, [openId]);
 
 	useEffect(() => {
 		if (popoverCloseTimeoutRef.current) {

--- a/src/components/launch/hooks/useLaunchHudInteractionState.ts
+++ b/src/components/launch/hooks/useLaunchHudInteractionState.ts
@@ -15,6 +15,7 @@ export function useLaunchHudInteractionState({
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
 	useEffect(() => {
+		window.electronAPI?.hudOverlaySetMenuOpen?.(openId !== null);
 		if (openId !== null) {
 			if (timeoutRef.current) clearTimeout(timeoutRef.current);
 			window.electronAPI?.hudOverlaySetIgnoreMouse?.(false);

--- a/src/components/launch/hooks/useLaunchHudInteractionState.ts
+++ b/src/components/launch/hooks/useLaunchHudInteractionState.ts
@@ -13,20 +13,35 @@ export function useLaunchHudInteractionState({
 }) {
 	const isMouseOverHudRef = useRef(false);
 	const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+	const popoverCloseTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+	const openIdRef = useRef(openId);
+	openIdRef.current = openId;
 
 	useEffect(() => {
+		if (popoverCloseTimeoutRef.current) {
+			clearTimeout(popoverCloseTimeoutRef.current);
+			popoverCloseTimeoutRef.current = null;
+		}
+
 		window.electronAPI?.hudOverlaySetMenuOpen?.(openId !== null);
 		if (openId !== null) {
 			if (timeoutRef.current) clearTimeout(timeoutRef.current);
 			window.electronAPI?.hudOverlaySetIgnoreMouse?.(false);
 		} else {
 			// Proactively check if we should ignore mouse when popover closes
-			setTimeout(() => {
-				if (!isMouseOverHudRef.current) {
+			popoverCloseTimeoutRef.current = setTimeout(() => {
+				if (openIdRef.current === null && !isMouseOverHudRef.current) {
 					window.electronAPI?.hudOverlaySetIgnoreMouse?.(true);
 				}
 			}, 150);
 		}
+
+		return () => {
+			if (popoverCloseTimeoutRef.current) {
+				clearTimeout(popoverCloseTimeoutRef.current);
+				popoverCloseTimeoutRef.current = null;
+			}
+		};
 	}, [openId]);
 
 	useEffect(() => {

--- a/src/components/launch/hooks/useLaunchWindowSystemState.ts
+++ b/src/components/launch/hooks/useLaunchWindowSystemState.ts
@@ -7,6 +7,9 @@ export function useLaunchWindowSystemState(
 	const [hudOverlayMousePassthroughSupported, setHudOverlayMousePassthroughSupported] = useState<
 		boolean | null
 	>(null);
+	const [hudOverlayResizeAnchor, setHudOverlayResizeAnchor] = useState<"bottom" | "center">(
+		"bottom",
+	);
 	const [platform, setPlatform] = useState<string | null>(null);
 	const [appVersion, setAppVersion] = useState<string | null>(null);
 	const [hideHudFromCapture, setHideHudFromCapture] = useState(true);
@@ -54,6 +57,7 @@ export function useLaunchWindowSystemState(
 				const result = await window.electronAPI.getHudOverlayMousePassthroughSupported();
 				if (!cancelled && result.success) {
 					setHudOverlayMousePassthroughSupported(result.supported);
+					setHudOverlayResizeAnchor(result.resizeAnchor ?? "bottom");
 				}
 			} catch (error) {
 				console.error("Failed to load HUD overlay mouse passthrough support:", error);
@@ -132,6 +136,7 @@ export function useLaunchWindowSystemState(
 	return {
 		recordingsDirectory,
 		hudOverlayMousePassthroughSupported,
+		hudOverlayResizeAnchor,
 		platform,
 		appVersion,
 		hideHudFromCapture,


### PR DESCRIPTION
## Description
Fixes two issues affecting the Linux HUD overlay on Wayland compositors (such as Hyprland):
1. HUD window disappearing/oscillating on hover: On Linux without mouse passthrough, the HUD window previously expanded from 160px to 540px immediately upon pointer hover. Because Wayland compositors center resizing floating windows around their midpoint, expanding a bottom-aligned window shifted the HUD bar away from the pointer, firing mouseleave and collapsing the window back to 160px in an endless oscillation loop that displaced the window off-screen.
2. Popover menu clipping: The compact non-passthrough HUD height was previously capped at 540px when expanded, which clipped the top portion of tall dropdown menus ("More", "Cam", "Microphone", presets, settings) which require up to ~680px clearance.

## Motivation
On Linux Wayland desktop environments, users running Recordly could not hover over or interact with the recording HUD because the window would instantly flicker and disappear. Additionally, opening dropdown menus resulted in clipped options. This PR ensures the HUD remains stable at its configured position and displays all popover contents without clipping.

## Type of Change
- [x] Bug Fix
- [ ] New Feature
- [ ] Refactor / Code Cleanup
- [x] Documentation Update
- [ ] Other

## Technical Details
- Menu-driven window expansion (electron/windows.ts, src/components/launch/hooks/useLaunchHudInteractionState.ts): Instead of expanding the fallback HUD window on hover, the window expands only when a popover menu is opened (openId !== null).
- Wayland resize anchoring (electron/hudOverlayBounds.ts, src/components/launch/LaunchWindow.tsx): Under Wayland sessions (XDG_SESSION_TYPE=wayland or WAYLAND_DISPLAY), the resize anchor is identified as center. The HUD container adjusts bottom padding dynamically (calc(50vh - 60px) vs 1.25rem) so that the HUD bar stays fixed in place on screen when the window geometry expands.
- Clearance increase (electron/hudOverlayBounds.ts): NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP is increased from 540 to 680 to accommodate tall popovers (such as the "More" dropdown menu).
- Unit tests updated (electron/hudOverlayBounds.test.ts): Test fixtures and assertions updated to reflect the 680px expanded height and test the getHudOverlayResizeAnchor platform/session detection.
- Compositor rules documented (README.md): Documents the required Hyprland/Omarchy window rules to prevent unwanted compositor decorations (blur, shadow, border, dimming) on transparent floating HUD windows.

## Related Issue(s)
Relates to #863

## Testing Guide
1. Launch Recordly on Linux under a Wayland session (e.g. Hyprland / Omarchy).
2. Hover over the HUD bar; verify that the bar does not oscillate or jump away from the pointer.
3. Click "More", "Cam", and "Mic" popovers; verify that each menu opens fully with all items visible without clipping at the top.
4. Close the menus; verify that the HUD returns to compact size smoothly.
5. Run unit tests with npm test to verify all hudOverlayBounds assertions pass.

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved recording HUD sizing and positioning across macOS, Windows, Linux/X11, and Linux/Wayland.
  * HUD menus now expand the overlay as needed while maintaining appropriate positioning.

* **Bug Fixes**
  * Improved HUD appearance and interaction behavior on Linux Wayland, including centered resizing.
  * Prevented delayed interaction changes while HUD menus open or close.

* **Documentation**
  * Added version-specific Hyprland and Omarchy window rule guidance for newer and older Hyprland releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->