### PR TITLE
Prevent closed console streams from crashing Recordly

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -64,7 +64,7 @@ const IS_SMOKE_EXPORT = process.env.RECORDLY_SMOKE_EXPORT === "1";
 
 function ignoreBrokenConsolePipe(stream: NodeJS.WritableStream | undefined) {
 	stream?.on("error", (error: NodeJS.ErrnoException) => {
-		if (error.code === "EPIPE") {
+		if (error.code === "EPIPE" || error.code === "EIO") {
 			return;
 		}
 		throw error;


### PR DESCRIPTION
## Summary
- treat macOS `EIO` from closed stdout/stderr streams like the already-handled `EPIPE` condition
- prevent harmless editor window logging from crashing the Electron main process
- preserve throwing for unexpected stream errors

## Verification
- `npx tsc --noEmit`
- `npx biome check electron/main.ts`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of console stream errors by safely ignoring additional broken-pipe conditions while continuing to surface unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->