### PR TITLE
Add a proper Windows installer setup

### DIFF
--- a/electron-builder.json5
+++ b/electron-builder.json5
@@ -105,10 +105,15 @@
     "target": [
       "nsis"
     ],
-    "icon": "icons/icons/win/icon.ico"
-    ,
+    "icon": "icons/icons/win/icon.ico",
     "executableName": "Recordly",
     "artifactName": "${productName}-windows-${arch}.${ext}"
+  },
+  "nsis": {
+    "oneClick": false,
+    "allowToChangeInstallationDirectory": true,
+    "createDesktopShortcut": true,
+    "createStartMenuShortcut": true,
+    "shortcutName": "Recordly"
   }
 }
-


### PR DESCRIPTION
## Description

This changes the Windows NSIS package from a silent one-click style install to a normal assisted installer. People can choose where Recordly is installed, select a per-user or per-machine installation, and launch it from desktop or Start Menu shortcuts.

## Motivation

The unpacked build works for development, but it does not behave like a regularly installed Windows application. The release installer should expose a real installation location and create the usual Windows entry points.

## Type of Change

- [x] New Feature
- [ ] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other

## Related Issue(s)

None.

## Screenshots / Video

Not applicable; this changes the native NSIS installer flow.

## Testing Guide

1. Build the Windows NSIS target.
2. Run Recordly-windows-x64.exe.
3. Confirm the installer offers per-user/per-machine installation and a destination-folder picker.
4. Complete installation and verify Recordly can be opened from its desktop and Start Menu shortcuts.

A local x64 NSIS installer was built successfully with oneClick=false and the resulting installer was launched.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos, or marked them not applicable.
- [x] I have linked related issues and updated the changelog if applicable, or marked them not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows installation now uses a guided setup wizard.
  * Users can choose the installation directory.
  * The installer creates desktop and Start Menu shortcuts named “Recordly.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->