### PR TITLE
fix(extensions): handle marketplace outages safely

### DIFF
--- a/electron/extensions/errorUtils.test.ts
+++ b/electron/extensions/errorUtils.test.ts
@@ -1,0 +1,84 @@
+﻿import { describe, expect, it } from "vitest";
+
+import { formatMarketplaceHttpError } from "./errorUtils";
+
+describe("formatMarketplaceHttpError", () => {
+	it("hides upstream HTML when the marketplace is unavailable", () => {
+		const html = "<!DOCTYPE html><html><body>SSL handshake failed</body></html>";
+
+		const message = formatMarketplaceHttpError({
+			status: 525,
+			contentType: "text/html; charset=UTF-8",
+			body: html,
+		});
+
+		expect(message).toBe(
+			"Marketplace is temporarily unavailable (HTTP 525). Please try again later.",
+		);
+		expect(message).not.toContain(html);
+	});
+
+	it("keeps a short JSON error for client-side request failures", () => {
+		expect(
+			formatMarketplaceHttpError({
+				status: 400,
+				contentType: "application/json",
+				body: JSON.stringify({ error: "Invalid search query" }),
+			}),
+		).toBe("Marketplace request failed (HTTP 400): Invalid search query");
+	});
+
+	it("uses a JSON message when an error field is absent", () => {
+		expect(
+			formatMarketplaceHttpError({
+				status: 409,
+				contentType: "application/json",
+				body: JSON.stringify({ message: "Extension version already exists" }),
+			}),
+		).toBe("Marketplace request failed (HTTP 409): Extension version already exists");
+	});
+
+	it("prefers a string error when both JSON detail fields are present", () => {
+		expect(
+			formatMarketplaceHttpError({
+				status: 400,
+				contentType: "application/json",
+				body: JSON.stringify({ error: "Primary detail", message: "Secondary detail" }),
+			}),
+		).toBe("Marketplace request failed (HTTP 400): Primary detail");
+	});
+
+	it("hides malformed JSON bodies", () => {
+		const body = '{"error":"internal route details"';
+		const message = formatMarketplaceHttpError({
+			status: 400,
+			contentType: "application/json",
+			body,
+		});
+
+		expect(message).toBe("Marketplace request failed (HTTP 400).");
+		expect(message).not.toContain(body);
+	});
+
+	it("bounds long JSON details and marks truncation without splitting Unicode", () => {
+		const detail = `🚀${"x".repeat(200)}`;
+		const message = formatMarketplaceHttpError({
+			status: 400,
+			contentType: "application/problem+json",
+			body: JSON.stringify({ error: detail }),
+		});
+
+		expect(message).toBe(`Marketplace request failed (HTTP 400): 🚀${"x".repeat(198)}…`);
+		expect(Array.from(message.split(": ")[1])).toHaveLength(200);
+	});
+
+	it("does not expose non-JSON response bodies", () => {
+		expect(
+			formatMarketplaceHttpError({
+				status: 404,
+				contentType: "text/plain",
+				body: "internal route details",
+			}),
+		).toBe("Marketplace request failed (HTTP 404).");
+	});
+});

--- a/electron/extensions/errorUtils.ts
+++ b/electron/extensions/errorUtils.ts
@@ -1,3 +1,43 @@
 export function getErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error);
 }
+
+const MAX_MARKETPLACE_ERROR_DETAIL_LENGTH = 200;
+
+export function formatMarketplaceHttpError({
+	status,
+	contentType,
+	body,
+}: {
+	status: number;
+	contentType: string | null;
+	body: string;
+}): string {
+	if (status >= 500) {
+		return `Marketplace is temporarily unavailable (HTTP ${status}). Please try again later.`;
+	}
+
+	let detail: string | null = null;
+	if (contentType?.toLowerCase().includes("json")) {
+		try {
+			const payload: unknown = JSON.parse(body);
+			if (payload && typeof payload === "object") {
+				const { error, message } = payload as { error?: unknown; message?: unknown };
+				const value = typeof error === "string" ? error : message;
+				if (typeof value === "string" && value.trim()) {
+					const normalized = value.trim().replace(/\s+/g, " ");
+					const codePoints = Array.from(normalized);
+					detail =
+						codePoints.length > MAX_MARKETPLACE_ERROR_DETAIL_LENGTH
+							? `${codePoints.slice(0, MAX_MARKETPLACE_ERROR_DETAIL_LENGTH - 1).join("")}…`
+							: normalized;
+				}
+			}
+		} catch {
+			// Malformed or non-API responses are intentionally not exposed to the renderer.
+		}
+	}
+
+	const summary = `Marketplace request failed (HTTP ${status})`;
+	return detail ? `${summary}: ${detail}` : `${summary}.`;
+}

--- a/electron/extensions/extensionMarketplace.ts
+++ b/electron/extensions/extensionMarketplace.ts
@@ -12,7 +12,7 @@ import { Readable } from "node:stream";
 import { pipeline } from "node:stream/promises";
 import type { ReadableStream as NodeReadableStream } from "node:stream/web";
 import { app } from "electron";
-import { getErrorMessage } from "./errorUtils";
+import { formatMarketplaceHttpError, getErrorMessage } from "./errorUtils";
 import { getRegisteredExtensions, installExtensionFromPath } from "./extensionLoader";
 import type {
 	ExtensionReview,
@@ -97,7 +97,13 @@ async function marketplaceFetch<T>(
 
 		if (!response.ok) {
 			const text = await response.text().catch(() => "");
-			throw new Error(`Marketplace API error ${response.status}: ${text}`);
+			throw new Error(
+				formatMarketplaceHttpError({
+					status: response.status,
+					contentType: response.headers.get("content-type"),
+					body: text,
+				}),
+			);
 		}
 
 		return (await response.json()) as T;


### PR DESCRIPTION
﻿## Description
Sanitize marketplace HTTP error responses and display a friendly message when upstream services fail. When the marketplace server is down or returning server errors such as Cloudflare 525, the application now shows a concise message and keeps the Retry button visible instead of rendering raw HTML into the panel.

## Motivation
When the extension marketplace encounters an outage or returns an upstream HTML error page (for example Cloudflare error 525 SSL handshake failed), the previous implementation dumped the raw HTML string into the user interface. This broke the panel layout and pushed the Retry button off-screen. By formatting HTTP error responses cleanly:
- 5xx responses display a short user-friendly message: "Marketplace is temporarily unavailable (HTTP <status>). Please try again later."
- 4xx client errors extract the concise JSON error message if present, or provide a brief status summary.
- The Browse tab layout remains intact, and the Retry button remains immediately visible and accessible.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
Fixes #735

## Screenshots / Video

**Screenshot** (if applicable):
- Before: Raw HTML error page rendered into the panel, pushing controls off-screen.
- After: Displays the ShieldAlert icon, short friendly error message, and the Retry button below it.

## Testing Guide
1. Run automated unit tests:
   ```bash
   npm test electron/extensions/errorUtils.test.ts
   ```
2. Verify that 5xx status codes (such as 525) produce the short friendly message:
   "Marketplace is temporarily unavailable (HTTP 525). Please try again later."
3. Verify in the UI that the Retry button remains visible and clickable when an error occurs.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos.
- [x] I have linked related issue(s) and updated the changelog if applicable.

---
*Thank you for contributing!*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marketplace error messages with clearer handling for server outages and API failures.
  * Prevented HTML, malformed, or overly long response content from appearing in user-facing errors.
  * Included useful error details from valid marketplace responses when available.

* **Tests**
  * Added coverage for marketplace error formatting, including JSON, non-JSON, malformed, and long Unicode content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->