### PR TITLE
Fix macOS release verification for universal binaries

### DIFF
--- a/electron/macosDistributionPolicy.test.mjs
+++ b/electron/macosDistributionPolicy.test.mjs
@@ -5,6 +5,7 @@ import {
 	collectCodeSigningMetadataErrors,
 	collectEntitlementErrors,
 	expectedMachOArchitecture,
+	hasMachOMagic,
 	parseLipoArchitectures,
 } from "../scripts/macos-distribution-policy.mjs";
 
@@ -95,6 +96,20 @@ describe("macOS distribution entitlement policy", () => {
 });
 
 describe("macOS distribution architecture policy", () => {
+	it("recognizes thin and universal Mach-O magic bytes without parsing file output", () => {
+		for (const header of [
+			[0xfe, 0xed, 0xfa, 0xce],
+			[0xcf, 0xfa, 0xed, 0xfe],
+			[0xca, 0xfe, 0xba, 0xbe],
+			[0xbf, 0xba, 0xfe, 0xca],
+		]) {
+			expect(hasMachOMagic(Uint8Array.from(header))).toBe(true);
+		}
+
+		expect(hasMachOMagic(Uint8Array.from([0x7f, 0x45, 0x4c, 0x46]))).toBe(false);
+		expect(hasMachOMagic(Uint8Array.from([0xfe, 0xed, 0xfa]))).toBe(false);
+	});
+
 	it("parses thin and fat lipo output", () => {
 		expect(parseLipoArchitectures("Non-fat file: App is architecture: arm64")).toEqual([
 			"arm64",

--- a/scripts/macos-distribution-policy.mjs
+++ b/scripts/macos-distribution-policy.mjs
@@ -1,5 +1,9 @@
 const TEAM_ID_PATTERN = /^[A-Z0-9]{10}$/;
 
+const MACH_O_MAGIC_NUMBERS = new Set([
+	0xfeedface, 0xfeedfacf, 0xcefaedfe, 0xcffaedfe, 0xcafebabe, 0xcafebabf, 0xbebafeca, 0xbfbafeca,
+]);
+
 export const REQUIRED_MACOS_ENTITLEMENTS = Object.freeze([
 	"com.apple.security.cs.allow-jit",
 	"com.apple.security.cs.allow-unsigned-executable-memory",
@@ -23,6 +27,15 @@ export function assertValidAppleTeamId(teamId) {
 	if (!TEAM_ID_PATTERN.test(teamId)) {
 		throw new Error("APPLE_TEAM_ID must be exactly 10 uppercase letters or digits");
 	}
+}
+
+export function hasMachOMagic(header) {
+	if (!(header instanceof Uint8Array) || header.byteLength < 4) {
+		return false;
+	}
+
+	const view = new DataView(header.buffer, header.byteOffset, header.byteLength);
+	return MACH_O_MAGIC_NUMBERS.has(view.getUint32(0, false));
 }
 
 export function collectCodeSigningMetadataErrors(details, expectedTeamId) {

--- a/scripts/verify-macos-distribution.mjs
+++ b/scripts/verify-macos-distribution.mjs
@@ -2,11 +2,14 @@
 
 import { spawnSync } from "node:child_process";
 import {
+	closeSync,
 	existsSync,
 	lstatSync,
 	mkdtempSync,
+	openSync,
 	readdirSync,
 	readFileSync,
+	readSync,
 	rmSync,
 	statSync,
 	writeFileSync,
@@ -19,6 +22,7 @@ import {
 	collectArchitectureErrors,
 	collectCodeSigningMetadataErrors,
 	collectEntitlementErrors,
+	hasMachOMagic,
 } from "./macos-distribution-policy.mjs";
 
 const projectRoot = process.cwd();
@@ -26,7 +30,6 @@ const packageJson = JSON.parse(readFileSync(path.join(projectRoot, "package.json
 const productName = packageJson.productName ?? packageJson.name ?? "Recordly";
 const expectedBundleId = "dev.recordly.app";
 const commandTimeoutMs = 5 * 60 * 1000;
-const fileClassificationBatchSize = 100;
 const maxReportDetailLength = 4_000;
 
 function parseArguments(argv) {
@@ -174,6 +177,17 @@ function walkRegularFiles(rootPath) {
 	return files;
 }
 
+function isMachOBinary(filePath) {
+	const header = new Uint8Array(4);
+	const descriptor = openSync(filePath, "r");
+	try {
+		const bytesRead = readSync(descriptor, header, 0, header.byteLength, 0);
+		return bytesRead === header.byteLength && hasMachOMagic(header);
+	} finally {
+		closeSync(descriptor);
+	}
+}
+
 function extractPlist(commandResult) {
 	const output = [commandResult.stdout, commandResult.stderr].filter(Boolean).join("\n");
 	const xmlStart = output.indexOf("<?xml");
@@ -281,23 +295,7 @@ function verifyEntitlements(appPath, label, tempRoot, check) {
 
 function verifyMachOBinaries(appPath, arch, check) {
 	check("packaged app: nested Mach-O signatures and architectures", () => {
-		const machOBinaries = [];
-		const regularFiles = walkRegularFiles(appPath);
-		for (let index = 0; index < regularFiles.length; index += fileClassificationBatchSize) {
-			const batch = regularFiles.slice(index, index + fileClassificationBatchSize);
-			const fileTypes = runProcess("file", ["-b", ...batch]).stdout.split(/\r?\n/);
-			if (fileTypes.length !== batch.length) {
-				throw new Error(
-					`file classification returned ${fileTypes.length} rows for ${batch.length} paths`,
-				);
-			}
-
-			for (let batchIndex = 0; batchIndex < batch.length; batchIndex += 1) {
-				if (fileTypes[batchIndex].includes("Mach-O")) {
-					machOBinaries.push(batch[batchIndex]);
-				}
-			}
-		}
+		const machOBinaries = walkRegularFiles(appPath).filter(isMachOBinary);
 
 		if (machOBinaries.length === 0) {
 			throw new Error("no Mach-O binaries were found in the app bundle");


### PR DESCRIPTION
## Summary
- detect Mach-O binaries from their magic bytes instead of parsing variable multiline  output
- preserve strict nested signature and architecture verification
- add coverage for thin and universal Mach-O headers

## Validation
- 
> recordly@1.4.0-beta.1 test
> vitest --run


 RUN  v2.1.9 /Users/young/Documents/Codex/2026-07-27/github-plugin-github-openai-curated-remote-2/recordly

 ✓ electron/ipc/captions/segment.test.ts (19 tests) 4ms
 ✓ src/components/video-editor/videoPlayback/zoomAnimation.test.ts (55 tests) 15ms
 ✓ electron/ipc/export/native-video.test.ts (74 tests) 9ms
 ✓ src/hooks/useScreenRecorder.test.ts (56 tests) 21ms
 ✓ src/components/video-editor/editorPreferences.test.ts (22 tests) 11ms
 ✓ electron/ipc/nativeVideoExport.test.ts (18 tests) 9ms
 ✓ src/lib/exporter/frameRenderer.test.ts (11 tests) 9ms
 ✓ src/lib/exporter/modernFrameRenderer.test.ts (16 tests) 19ms
 ✓ electron/navigationPolicy.test.ts (33 tests) 56ms
 ✓ src/components/video-editor/audio.test.ts (25 tests) 30ms
stdout | electron/ipc/recording/diagnostics.test.ts > getCompanionAudioFallbackPaths > writes a recording diagnostics sidecar with stream and audio probes
[PERF:MAIN] probeMediaDurationSeconds: COMPLETED in 0ms
[PERF:MAIN] probeVideoStreamDuration: COMPLETED in 0ms
[PERF:MAIN] probeMediaDurationSeconds: COMPLETED in 0ms

 ✓ electron/ipc/recording/diagnostics.test.ts (12 tests) 268ms
 ✓ src/lib/exporter/gifExporter.test.ts (18 tests) 29ms
 ✓ src/components/video-editor/timeline/dnd/engine.test.ts (19 tests) 4ms
 ✓ src/lib/announcements.test.ts (11 tests) 4ms
 ✓ src/lib/exporter/audioEncoder.test.ts (7 tests) 8ms
 ✓ src/components/video-editor/timeline/zoomSuggestionUtils.test.ts (15 tests) 4ms
stdout | src/lib/exporter/modernVideoExporter.fallback.test.ts > ModernVideoExporter native fallback routing > falls back to WebCodecs instead of surfacing a native error when Breeze is unavailable
[VideoExporter] Backpressure profile {
  profile: 'breeze-balanced-plus',
  encodeBackend: 'ffmpeg',
  maxEncodeQueue: 72,
  maxDecodeQueue: 14,
  maxPendingFrames: 40,
  maxInFlightNativeWrites: 1
}
[VideoExporter] Using webgl render backend
[VideoExporter] Original duration: 1 s
[VideoExporter] Effective duration: 0 s
[VideoExporter] Total frames to export: 0
[VideoExporter] Using WebCodecs encode path
[VideoExporter] Progress {"phase":"finalizing","currentFrame":0,"totalFrames":0,"elapsedSec":0,"averageRenderFps":0,"sampleRenderFps":0,"displayedRenderFps":0,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Progress {"phase":"finalizing","currentFrame":0,"totalFrames":0,"elapsedSec":0,"averageRenderFps":0,"sampleRenderFps":0,"displayedRenderFps":0,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Progress {"phase":"finalizing","currentFrame":0,"totalFrames":0,"elapsedSec":0,"averageRenderFps":0,"sampleRenderFps":0,"displayedRenderFps":0,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Final metrics {"totalElapsedMs":3.268957999999998,"metadataLoadMs":0.01712499999996453,"rendererInitMs":0.11162500000000364,"nativeSessionStartMs":0.014417000000037206,"decodeLoopMs":0.012458000000037828,"frameCallbackMs":0,"renderFrameMs":0,"encodeWaitMs":0,"encodeWaitEvents":0,"peakEncodeQueueSize":0,"peakNativeWriteInFlight":0,"nativeCaptureMs":0,"nativeWriteMs":0,"finalizationMs":0.4627079999999637,"frameCount":0,"renderBackend":"webgl","backpressureProfile":"webcodecs-balanced-plus","finalizationStageMs":{"queuedMuxingMs":0.16816599999998516,"muxerFinalizeMs":0.12770799999998417}}

stdout | src/lib/exporter/modernVideoExporter.fallback.test.ts > ModernVideoExporter native fallback routing > keeps Windows auto exports on the streaming native route before static layout
[VideoExporter] Backpressure profile {
  profile: 'breeze-balanced-plus',
  encodeBackend: 'ffmpeg',
  maxEncodeQueue: 72,
  maxDecodeQueue: 14,
  maxPendingFrames: 40,
  maxInFlightNativeWrites: 8
}
[VideoExporter] Using webgl render backend
[VideoExporter] Original duration: 1 s
[VideoExporter] Effective duration: 0 s
[VideoExporter] Total frames to export: 0
[VideoExporter] Using Breeze native encode path
[VideoExporter] Progress {"phase":"finalizing","currentFrame":0,"totalFrames":0,"elapsedSec":0,"averageRenderFps":0,"sampleRenderFps":0,"displayedRenderFps":0,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Progress {"phase":"finalizing","currentFrame":0,"totalFrames":0,"elapsedSec":0,"averageRenderFps":0,"sampleRenderFps":0,"displayedRenderFps":0,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Final metrics {"totalElapsedMs":0.57325000000003,"metadataLoadMs":0.0054580000000328255,"rendererInitMs":0.04975000000001728,"nativeSessionStartMs":0.022416000000021086,"decodeLoopMs":0.003958000000011452,"frameCallbackMs":0,"renderFrameMs":0,"encodeWaitMs":0,"encodeWaitEvents":0,"peakEncodeQueueSize":0,"peakNativeWriteInFlight":0,"nativeCaptureMs":0,"nativeWriteMs":0,"finalizationMs":0.032290999999986525,"frameCount":0,"renderBackend":"webgl","backpressureProfile":"breeze-balanced-plus"}

stdout | src/lib/exporter/modernVideoExporter.fallback.test.ts > ModernVideoExporter native fallback routing > tries Windows auto static-layout first when NVIDIA CUDA is opted in
[VideoExporter] Backpressure profile {
  profile: 'breeze-balanced-plus',
  encodeBackend: 'ffmpeg',
  maxEncodeQueue: 72,
  maxDecodeQueue: 14,
  maxPendingFrames: 40,
  maxInFlightNativeWrites: 1
}
[VideoExporter] Final metrics {"totalElapsedMs":0.1389159999999947,"metadataLoadMs":0,"rendererInitMs":0,"nativeSessionStartMs":0,"decodeLoopMs":0,"frameCallbackMs":0,"renderFrameMs":0,"encodeWaitMs":0,"encodeWaitEvents":0,"peakEncodeQueueSize":0,"peakNativeWriteInFlight":0,"nativeCaptureMs":0,"nativeWriteMs":0,"finalizationMs":0,"frameCount":0,"backpressureProfile":"breeze-balanced-plus","effectiveDurationSec":1}

stdout | src/lib/exporter/modernVideoExporter.fallback.test.ts > ModernVideoExporter native fallback routing > retries the main decode path once with a fresh media source
[VideoExporter] Backpressure profile {
  profile: 'webcodecs-balanced-plus',
  encodeBackend: 'webcodecs',
  maxEncodeQueue: 72,
  maxDecodeQueue: 12,
  maxPendingFrames: 32,
  maxInFlightNativeWrites: 1
}
[VideoExporter] Using webgl render backend
[VideoExporter] Original duration: 1 s
[VideoExporter] Effective duration: 1 s
[VideoExporter] Total frames to export: 30
[VideoExporter] Using WebCodecs encode path
[VideoExporter] Backpressure profile {
  profile: 'webcodecs-balanced-plus',
  encodeBackend: 'webcodecs',
  maxEncodeQueue: 72,
  maxDecodeQueue: 12,
  maxPendingFrames: 32,
  maxInFlightNativeWrites: 1
}
[VideoExporter] Using webgl render backend
[VideoExporter] Original duration: 1 s
[VideoExporter] Effective duration: 1 s
[VideoExporter] Total frames to export: 30
[VideoExporter] Using WebCodecs encode path
[VideoExporter] Progress {"phase":"finalizing","currentFrame":30,"totalFrames":30,"elapsedSec":0,"averageRenderFps":30000,"sampleRenderFps":30000,"displayedRenderFps":30000,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Progress {"phase":"finalizing","currentFrame":30,"totalFrames":30,"elapsedSec":0,"averageRenderFps":30000,"sampleRenderFps":0,"displayedRenderFps":10500,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Progress {"phase":"finalizing","currentFrame":30,"totalFrames":30,"elapsedSec":0,"averageRenderFps":30000,"sampleRenderFps":0,"displayedRenderFps":3675,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Final metrics {"totalElapsedMs":0.5269999999999868,"metadataLoadMs":0.10287499999998317,"rendererInitMs":0.025708000000008724,"nativeSessionStartMs":0,"decodeLoopMs":0.011749999999949523,"frameCallbackMs":0,"renderFrameMs":0,"encodeWaitMs":0,"encodeWaitEvents":0,"peakEncodeQueueSize":0,"peakNativeWriteInFlight":0,"nativeCaptureMs":0,"nativeWriteMs":0,"finalizationMs":0.07504199999999628,"frameCount":0,"renderBackend":"webgl","backpressureProfile":"webcodecs-balanced-plus","effectiveDurationSec":1,"finalizationStageMs":{"queuedMuxingMs":0.013792000000023563,"muxerFinalizeMs":0.019624999999962256}}

stdout | src/lib/exporter/modernVideoExporter.fallback.test.ts > ModernVideoExporter native fallback routing > forwards cursor click-effect settings into the modern frame renderer
[VideoExporter] Backpressure profile {
  profile: 'webcodecs-balanced-plus',
  encodeBackend: 'webcodecs',
  maxEncodeQueue: 72,
  maxDecodeQueue: 12,
  maxPendingFrames: 32,
  maxInFlightNativeWrites: 1
}
[VideoExporter] Using webgl render backend
[VideoExporter] Original duration: 1 s
[VideoExporter] Effective duration: 1 s
[VideoExporter] Total frames to export: 30
[VideoExporter] Using WebCodecs encode path
[VideoExporter] Progress {"phase":"finalizing","currentFrame":30,"totalFrames":30,"elapsedSec":0,"averageRenderFps":30000,"sampleRenderFps":30000,"displayedRenderFps":30000,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Progress {"phase":"finalizing","currentFrame":30,"totalFrames":30,"elapsedSec":0,"averageRenderFps":30000,"sampleRenderFps":0,"displayedRenderFps":10500,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Progress {"phase":"finalizing","currentFrame":30,"totalFrames":30,"elapsedSec":0,"averageRenderFps":30000,"sampleRenderFps":0,"displayedRenderFps":3675,"renderBackend":"webgl","encoderQueueSize":0,"pendingEncodeQueue":0,"encodeBacklog":0,"peakEncodeQueueSize":0,"nativeWriteInFlight":0,"peakNativeWriteInFlight":0,"averageFrameCallbackMs":0,"averageRenderFrameMs":0,"averageEncodeWaitMs":0}
[VideoExporter] Final metrics {"totalElapsedMs":0.4777920000000222,"metadataLoadMs":0.00591700000001083,"rendererInitMs":0.03983299999998735,"nativeSessionStartMs":0,"decodeLoopMs":0.0028340000000071086,"frameCallbackMs":0,"renderFrameMs":0,"encodeWaitMs":0,"encodeWaitEvents":0,"peakEncodeQueueSize":0,"peakNativeWriteInFlight":0,"nativeCaptureMs":0,"nativeWriteMs":0,"finalizationMs":0.13495799999998326,"frameCount":0,"renderBackend":"webgl","backpressureProfile":"webcodecs-balanced-plus","effectiveDurationSec":1,"finalizationStageMs":{"queuedMuxingMs":0.01887499999997999,"muxerFinalizeMs":0.0272499999999809}}

 ✓ src/lib/exporter/modernVideoExporter.fallback.test.ts (5 tests) 315ms
 ✓ src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts (31 tests) 26ms
 ✓ electron/permissionPolicy.test.ts (53 tests) 7ms
 ✓ electron/ipc/captions/silence.test.ts (12 tests) 5ms
 ✓ src/lib/exporter/muxer.test.ts (3 tests) 6ms
 ✓ src/components/video-editor/videoPlayback/videoEventHandlers.test.ts (5 tests) 3ms
 ✓ src/lib/exporter/finalizationTimeout.test.ts (9 tests) 7ms
 ✓ electron/ipc/project/manager.test.ts (10 tests) 301ms
 ✓ src/components/video-editor/captionOps.test.ts (11 tests) 12ms
 ✓ src/components/video-editor/exportStatusModel.test.ts (9 tests) 4ms
 ✓ src/lib/exporter/backendPolicy.test.ts (9 tests) 2ms
 ✓ src/components/video-editor/clipSpeedChange.test.ts (9 tests) 2ms
 ✓ src/lib/mediaTiming.test.ts (19 tests) 4ms
 ✓ src/lib/exporter/streamingDecoder.test.ts (10 tests) 8ms
 ✓ src/components/video-editor/videoPlayback/zoomTransform.test.ts (4 tests) 3ms
 ✓ electron/ipc/ffmpeg/filters.test.ts (15 tests) 4ms
 ✓ electron/macosDistributionPolicy.test.mjs (11 tests) 6ms
 ✓ src/components/video-editor/types.test.ts (17 tests) 3ms
 ✓ src/lib/pixiApplicationLifecycle.test.ts (6 tests) 4ms
 ✓ src/lib/exporter/editedTrackStrategy.test.ts (8 tests) 3ms
 ✓ electron/ipc/export/exportStream.test.ts (6 tests) 20ms
 ✓ src/components/video-editor/editorHistory.test.ts (8 tests) 2ms
 ✓ src/components/video-editor/captionEditing.test.ts (5 tests) 3ms
 ✓ src/components/video-editor/timeline/model/timelineModel.test.ts (5 tests) 3ms
 ✓ electron/ipc/recording/windows.test.ts (8 tests) 9ms
 ✓ electron/ipc/export/nativeStaticLayoutRoutePlan.test.ts (4 tests) 2ms
 ✓ electron/ipc/recording/prune.test.ts (2 tests) 144ms
 ✓ src/lib/exporter/nativeStaticLayoutTelemetry.test.ts (5 tests) 6ms
 ✓ electron/hudOverlayBounds.test.ts (12 tests) 2ms
 ✓ electron/ipc/cursor/telemetry.test.ts (5 tests) 6ms
 ✓ electron/ipc/project/atomicSave.test.ts (6 tests) 206ms
 ✓ src/components/video-editor/exportDimensions.test.ts (10 tests) 4ms
 ✓ electron/native/ScreenCaptureKitRecorder.test.ts (8 tests) 3ms
 ✓ src/components/video-editor/webcamOverlay.test.ts (11 tests) 24ms
 ✓ src/lib/assetPath.test.ts (8 tests) 5ms
 ✓ electron/ipc/windowsCaptureSelection.test.ts (7 tests) 4ms
 ✓ src/components/video-editor/smokeExportConfig.test.ts (4 tests) 3ms
 ✓ src/components/video-editor/projectPersistence.test.ts (9 tests) 3ms
 ✓ src/components/video-editor/smokeExportProgress.test.ts (6 tests) 4ms
 ✓ electron/mediaServer.test.ts (6 tests) 55ms
 ✓ src/components/video-editor/videoPlayback/webcamSync.test.ts (10 tests) 1ms
 ✓ src/lib/exporter/localMediaSource.test.ts (6 tests) 5ms
 ✓ electron/ipc/cursor/interaction.test.ts (4 tests) 28ms
 ✓ src/lib/exporter/exportBitrate.test.ts (6 tests) 2ms
 ✓ electron/ipc/register/exportCaptionSidecars.test.ts (6 tests) 13ms
 ✓ src/hooks/recordingMimeType.test.ts (8 tests) 4ms
 ✓ src/lib/exporter/exportTuning.test.ts (5 tests) 1ms
 ✓ src/components/video-editor/projectDirtyState.test.ts (7 tests) 2ms
 ✓ src/lib/wallpapers.test.ts (5 tests) 5ms
 ✓ src/components/video-editor/mp4ExportRouting.test.ts (4 tests) 3ms
 ✓ src/lib/exporter/temporalMotionBlur.test.ts (7 tests) 2ms
 ✓ src/components/video-editor/videoPlayback/cursorFollowCamera.test.ts (4 tests) 2ms
 ✓ electron/ipc/recording/windowsFallbacks.test.ts (8 tests) 2ms
 ✓ electron/ipc/register/export.test.ts (2 tests) 14ms
 ✓ electron/ipc/recording/audioFilters.test.ts (4 tests) 4ms
 ✓ src/components/video-editor/timeline/sourceAudioTracks.test.ts (5 tests) 3ms
 ✓ src/components/video-editor/audio/audioResourceVersion.test.ts (5 tests) 6ms
 ✓ electron/mainCjsNormalize.test.mjs (4 tests) 3ms
 ✓ electron/ipc/paths/binaries.test.ts (3 tests) 115ms
 ✓ src/components/video-editor/timeline/core/time.test.ts (6 tests) 3ms
 ✓ src/lib/exporter/sourceAudioFallback.test.ts (5 tests) 3ms
 ✓ src/components/video-editor/useNvidiaCudaExportOptIn.test.ts (4 tests) 4ms
 ✓ src/components/video-editor/videoPlayback/layoutUtils.test.ts (5 tests) 3ms
 ✓ electron/windowsCmakeGenerators.test.mjs (3 tests) 3ms
 ✓ src/contexts/ThemeContext.test.ts (3 tests) 2ms
 ✓ src/components/launch/hudMousePassthrough.test.ts (6 tests) 1ms
 ✓ src/components/video-editor/mp4ExportSettings.test.ts (4 tests) 5ms
 ✓ electron/gpuSwitches.test.ts (7 tests) 3ms
 ✓ src/components/video-editor/autoCaptionSource.test.ts (5 tests) 3ms
 ✓ electron/ipc/recording/storagePath.test.ts (25 tests) 3ms
 ✓ src/components/video-editor/exportProgressState.test.ts (3 tests) 1ms
 ✓ src/lib/exporter/types.test.ts (3 tests) 9ms
 ✓ src/lib/exporter/mp4Support.test.ts (2 tests) 6ms
 ✓ src/components/video-editor/timeline/core/rows.test.ts (4 tests) 2ms
 ✓ src/components/video-editor/audio/waveform/waveformCache.test.ts (2 tests) 1ms
 ✓ src/lib/exporter/exportSavePolicy.test.ts (5 tests) 1ms
 ✓ src/components/video-editor/timeline/timelineLayout.test.ts (4 tests) 2ms
 ✓ src/lib/exporter/sourceTrackRoutingPolicy.test.ts (3 tests) 5ms
 ✓ src/components/video-editor/timeline/core/spans.test.ts (6 tests) 4ms
 ✓ src/components/video-editor/timeline/hooks/utils/timelineSelectionUtils.test.ts (3 tests) 1ms
 ✓ src/components/video-editor/videoPlayback/cursorSway.test.ts (5 tests) 2ms
 ✓ src/components/video-editor/exportStartSettings.test.ts (3 tests) 4ms
 ✓ electron/ipc/register/sourceMapping.test.ts (4 tests) 4ms
 ✓ electron/ipc/settings/recordingPreferencesStore.test.ts (1 test) 35ms
 ✓ src/components/video-editor/captionLayout.test.ts (1 test) 2ms
 ✓ src/components/video-editor/timeline/hooks/useTimelineRange.test.ts (4 tests) 6ms
 ✓ src/components/video-editor/timeline/hooks/utils/timelineAudioPlacement.test.ts (3 tests) 2ms
 ✓ electron/ipc/captions/audioCandidates.test.ts (2 tests) 2ms
 ✓ src/lib/exporter/nativeStaticLayoutGeometry.test.ts (3 tests) 2ms
 ✓ src/lib/exporter/mediaResource.test.ts (4 tests) 2ms
 ✓ electron/ipc/recording/macCompanionAudio.test.ts (3 tests) 1ms
 ✓ src/components/video-editor/videoPlayback/cursorViewport.test.ts (3 tests) 3ms
 ✓ src/lib/hudCaptureProtection.test.ts (10 tests) 4ms
 ✓ src/lib/exporter/shadowProfile.test.ts (2 tests) 3ms
 ✓ src/components/launch/hudViewportBounds.test.ts (3 tests) 1ms
 ✓ src/components/launch/floatingWebcamPreview.test.ts (3 tests) 2ms
 ✓ src/components/video-editor/videoPlayback/uploadedCursorAssets.test.ts (2 tests) 1ms
 ✓ electron/updateChannel.test.ts (3 tests) 1ms
 ✓ electron/hudCaptureProtection.test.ts (2 tests) 7ms
 ✓ electron/ipc/captions/generate.test.ts (2 tests) 2ms
 ✓ src/components/video-editor/export/useExportMessages.test.ts (2 tests) 4ms
 ✓ src/components/video-editor/videoPlayback/cursorScale.test.ts (1 test) 1ms
 ✓ src/lib/exporter/videoColorSpace.test.ts (1 test) 1ms
 ✓ electron/hudOverlayWindowOptions.test.ts (3 tests) 1ms

 Test Files  120 passed (120)
      Tests  1083 passed (1083)
   Start at  20:05:31
   Duration  3.63s (transform 2.48s, setup 0ms, collect 7.25s, tests 2.11s, environment 15ms, prepare 5.77s) (120 files, 1083 tests)
- 
- Biome and diff checks

Required to build the private v1.4.0-beta.1 draft assets after Apple notarization succeeded but the verifier produced a false row-count failure.