### PR TITLE
fix(preview): stop leaking video sources on layout changes

### DIFF
--- a/src/components/video-editor/VideoPlayback.tsx
+++ b/src/components/video-editor/VideoPlayback.tsx
@@ -1,4 +1,4 @@
-import { Application, Container, Graphics, Rectangle, Sprite, Texture, VideoSource } from "pixi.js";
+import { Application, Container, Graphics, Rectangle, Sprite, Texture } from "pixi.js";
 import { MotionBlurFilter } from "pixi-filters/motion-blur";
 import { ZoomBlurFilter } from "pixi-filters/zoom-blur";
 import type React from "react";
@@ -111,6 +111,7 @@ import {
 	stepSpringValue,
 } from "./videoPlayback/motionSmoothing";
 import { updateOverlayIndicator } from "./videoPlayback/overlayUtils";
+import { PreviewVideoSource } from "./videoPlayback/previewVideoSource";
 import { createVideoEventHandlers } from "./videoPlayback/videoEventHandlers";
 import {
 	getWebcamMediaTargetTimeSeconds,
@@ -381,6 +382,13 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 		ref,
 	) => {
 		const videoRef = useRef<HTMLVideoElement | null>(null);
+		const previewVideoSourceRef = useRef(new PreviewVideoSource());
+		const attachVideo = useCallback((video: HTMLVideoElement | null) => {
+			// VideoSource.destroy() clears the media URL, so only destroy it when
+			// React detaches the element, never during a layout effect cleanup.
+			previewVideoSourceRef.current.setVideo(video);
+			videoRef.current = video;
+		}, []);
 		const previewFrameRef = useRef<HTMLDivElement | null>(null);
 		const containerRef = useRef<HTMLDivElement | null>(null);
 		const appRef = useRef<Application | null>(null);
@@ -1944,13 +1952,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				return;
 			if (video.videoWidth === 0 || video.videoHeight === 0) return;
 
-			const source = VideoSource.from(video);
-			if ("autoPlay" in source) {
-				(source as { autoPlay?: boolean }).autoPlay = false;
-			}
-			if ("autoUpdate" in source) {
-				(source as { autoUpdate?: boolean }).autoUpdate = true;
-			}
+			const source = previewVideoSourceRef.current.getSource();
 			const videoTexture = Texture.from(source);
 
 			const videoSprite = new Sprite(videoTexture);
@@ -1967,7 +1969,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 
 			animationStateRef.current = createPlaybackAnimationState();
 
-			layoutVideoContent();
+			layoutVideoContentRef.current?.();
 			video.pause();
 
 			const { handlePlay, handlePause, handleSeeked, handleSeeking, dispose } =
@@ -2004,10 +2006,11 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				destroyPixiContainer(maskGraphics);
 				maskGraphicsRef.current = null;
 				if (!videoTexture.destroyed) videoTexture.destroy(false);
+				previewVideoSourceRef.current.suspend();
 
 				videoSpriteRef.current = null;
 			};
-		}, [layoutVideoContent, onPlayStateChange, onTimeUpdate, pixiReady, videoReady]);
+		}, [onPlayStateChange, onTimeUpdate, pixiReady, videoReady]);
 
 		useEffect(() => {
 			if (!pixiReady || !videoReady) return;
@@ -2885,7 +2888,7 @@ const VideoPlayback = forwardRef<VideoPlaybackRef, VideoPlaybackProps>(
 				{/* Keep the source video off-screen instead of display:none so the
 					browser continues producing presented frames for Pixi and preview sync. */}
 				<video
-					ref={videoRef}
+					ref={attachVideo}
 					src={videoPath}
 					className={fallbackVideoClassName}
 					preload="metadata"

--- a/src/components/video-editor/videoPlayback/previewVideoSource.test.ts
+++ b/src/components/video-editor/videoPlayback/previewVideoSource.test.ts
@@ -1,0 +1,125 @@
+import { DOMAdapter, Texture } from "pixi.js";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { PreviewVideoSource } from "./previewVideoSource";
+
+class TestVideo extends EventTarget {
+	videoWidth = 5120;
+	videoHeight = 2880;
+	width = 5120;
+	height = 2880;
+	readyState = 4;
+	HAVE_ENOUGH_DATA = 4;
+	HAVE_FUTURE_DATA = 3;
+	paused = true;
+	ended = false;
+	src = "recording.mp4";
+	currentTime = 5;
+	playbackRate = 1;
+	play = vi.fn();
+	pause = vi.fn();
+	load = vi.fn();
+	requestVideoFrameCallback = vi.fn(() => 1);
+	cancelVideoFrameCallback = vi.fn();
+	listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+
+	override addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+		const listeners = this.listeners.get(type) ?? new Set();
+		listeners.add(listener);
+		this.listeners.set(type, listeners);
+		super.addEventListener(type, listener);
+	}
+
+	override removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+		this.listeners.get(type)?.delete(listener);
+		super.removeEventListener(type, listener);
+	}
+
+	asElement() {
+		return this as unknown as HTMLVideoElement;
+	}
+}
+
+const originalAdapter = DOMAdapter.get();
+beforeAll(() => {
+	DOMAdapter.set({
+		...originalAdapter,
+		createCanvas: () => ({ getContext: () => null }) as unknown as HTMLCanvasElement,
+	});
+});
+afterAll(() => DOMAdapter.set(originalAdapter));
+
+describe("PreviewVideoSource", () => {
+	it("reuses a single source and listener set across repeated texture lifecycles", async () => {
+		const video = new TestVideo();
+		const owner = new PreviewVideoSource();
+		owner.setVideo(video.asElement());
+		const source = owner.getSource();
+		await source.load();
+		const unload = vi.fn();
+		source.on("unload", unload);
+
+		for (let i = 0; i < 100; i++) {
+			expect(owner.getSource()).toBe(source);
+			const texture = new Texture({ source });
+			texture.destroy(false);
+			owner.suspend();
+		}
+
+		expect(source.destroyed).toBe(false);
+		expect(unload).toHaveBeenCalledTimes(100);
+		for (const type of ["play", "pause", "seeked"]) {
+			expect(video.listeners.get(type)?.size).toBe(1);
+		}
+		expect(video.src).toBe("recording.mp4");
+		expect(video.currentTime).toBe(5);
+		expect(video.play).not.toHaveBeenCalled();
+		expect(video.load).not.toHaveBeenCalled();
+
+		owner.setVideo(null);
+		expect(source.destroyed).toBe(true);
+		for (const listeners of video.listeners.values()) expect(listeners.size).toBe(0);
+	});
+
+	it("updates paused seeks and new media dimensions after resuming", async () => {
+		const video = new TestVideo();
+		const owner = new PreviewVideoSource();
+		owner.setVideo(video.asElement());
+		const source = owner.getSource();
+		await source.load();
+		const update = vi.fn();
+		source.on("update", update);
+		video.dispatchEvent(new Event("seeked"));
+		expect(update).toHaveBeenCalledTimes(1);
+		owner.suspend();
+		video.dispatchEvent(new Event("seeked"));
+		expect(update).toHaveBeenCalledTimes(1);
+		video.videoWidth = 1920;
+		video.videoHeight = 1080;
+		owner.getSource();
+		expect(source.pixelWidth).toBe(1920);
+		expect(source.pixelHeight).toBe(1080);
+		owner.setVideo(null);
+	});
+
+	it("cancels frame callbacks and releases the source when the element detaches", async () => {
+		const video = new TestVideo();
+		const owner = new PreviewVideoSource();
+		owner.setVideo(video.asElement());
+		const source = owner.getSource();
+		await source.load();
+		video.paused = false;
+		video.dispatchEvent(new Event("play"));
+		expect(video.requestVideoFrameCallback).toHaveBeenCalledTimes(1);
+		owner.setVideo(null);
+		expect(video.cancelVideoFrameCallback).toHaveBeenCalledWith(1);
+		expect(source.destroyed).toBe(true);
+		owner.setVideo(null);
+		expect(video.load).toHaveBeenCalledTimes(1);
+		expect(() => owner.getSource()).toThrow("not attached");
+		const nextVideo = new TestVideo();
+		owner.setVideo(nextVideo.asElement());
+		expect(owner.getSource()).not.toBe(source);
+		await owner.getSource().load();
+		owner.setVideo(null);
+	});
+});

--- a/src/components/video-editor/videoPlayback/previewVideoSource.ts
+++ b/src/components/video-editor/videoPlayback/previewVideoSource.ts
@@ -1,0 +1,33 @@
+import { VideoSource } from "pixi.js";
+
+/** Own the GPU source for the lifetime of React's persistent video element. */
+export class PreviewVideoSource {
+	private video: HTMLVideoElement | null = null;
+	private source: VideoSource | null = null;
+
+	setVideo(video: HTMLVideoElement | null): void {
+		if (video === this.video) return;
+
+		if (this.source) {
+			this.source.autoUpdate = false;
+			this.source.destroy();
+			this.source = null;
+		}
+		this.video = video;
+	}
+
+	getSource(): VideoSource {
+		if (!this.video) throw new Error("Preview video element is not attached");
+		this.source ??= new VideoSource({ resource: this.video, autoPlay: false });
+		this.source.autoUpdate = true;
+		// React can load another media URL into the same element.
+		this.source.update();
+		return this.source;
+	}
+
+	suspend(): void {
+		if (!this.source) return;
+		this.source.autoUpdate = false;
+		this.source.unload();
+	}
+}


### PR DESCRIPTION
## Description
Changing the preview radius or padding recreated `VideoSource` through the `layoutVideoContent` effect dependency. Cleanup called `videoTexture.destroy(false)`, leaving each source's GPU allocation and `play`/`pause`/`seeked` listeners alive. `VideoSource.from(video)` creates a fresh source on every call; it does not cache by video element.

Reuse one source for React's persistent video element, unload GPU data and suspend updates when the sprite effect cleans up, and destroy the source when React detaches the element. Keep geometric layout changes independent of the texture/event-handler effect. Set `autoPlay: false` at construction to avoid starting playback before the old post-construction assignment.

The owner is necessary because Pixi's `VideoSource.destroy()` also clears `video.src` and reloads it. Calling `texture.destroy(true)` on every effect cleanup would disrupt React's persistent media element.

## Motivation
Investigated a 19.8-second 5120×2880 recording on macOS with Recordly 1.4.0-beta.1. After radius adjustment and scrubbing, the GPU helper retained 12.9 GiB physical footprint (13.6 GiB peak), including about 12 GiB in IOAccelerator graphics allocations, while the editor renderer footprint was 334 MiB.

An isolated Electron/Pixi reproduction using a synthetic 5120×2880 video and 30 texture creation/render/cleanup cycles confirmed the source lifetime leak:

| Measurement | Existing lifecycle | Updated lifecycle |
| --- | --- | --- |
| GPU process physical footprint | 3.8 GiB | 252.4 MiB |
| GPU process peak footprint | 3.9 GiB | 385.6 MiB |
| Retained listeners per video event (`play`, `pause`, `seeked`) | 30 | 1 |

The table above measures the isolated reproduction. Full editor validation with the built application is recorded below. No recordings or raw user diagnostic dumps are included.

## Type of Change
- [x] Bug Fix

## Related Issue(s)
No existing issue linked.

## Testing Guide
- `npm test`: 121 test files / 1,086 tests passed.
- `npx tsc --noEmit`: passed.
- `npx vite build`: passed (renderer and Electron bundles; not a packaged installer).
- Biome lint on all three changed files: passed.
- New tests use real Pixi sources with a test video element to cover 100 texture lifecycles, bounded event listeners, GPU unload events, paused seeks, media dimension changes, frame callback cancellation, and element detachment.
- Manual integration check: open a high-resolution recording, repeatedly adjust radius/padding and scrub, verify geometry and playback still work, then open another recording and close the editor. GPU memory should remain bounded. Check process physical footprint with `vmmap -summary <GPU helper PID>`; RSS alone misses much of the graphics allocation on macOS.

### Full editor validation on macOS

Validated the built renderer and Electron main process from commit `f0faa06a` with Electron 43.1.0, a separate test profile, and a local copy of the original 5120×2880 / 19.8-second recording. This ran the actual Recordly editor rather than the synthetic lifecycle harness; the installed app was not replaced.

- Changed radius 120 times (two rounds of 30 increments and 30 decrements), changed padding 20 times, played the video, and scrubbed/seeked repeatedly in both directions. The preview rendered correctly and playback continued to advance.
- Imported a 1920×1080 / 2-second clip into the same editor and verified its preview and playback through the end.
- Closed the editor, discarding only test edits, and observed GPU memory release.

All measurements below are physical footprint of the same GPU helper process, from `vmmap -summary`:

| Checkpoint | GPU physical footprint |
| --- | --- |
| After first 30 radius changes | 988.1 MiB |
| After 60 radius changes, padding changes, playback and scrubbing | 928.4 MiB |
| After 120 radius changes and additional repeated seeks | 907.2 MiB |
| After switching to the 1080p clip | 734.1 MiB |
| After closing the editor | 99.5 MiB |

Peak GPU footprint for this process was 1.3 GiB. There was no monotonic memory growth during the repeated edits. This validates the preview regression on the tested machine; packaged distribution/signing and recording/export paths were not part of this test.

## Checklist
- [x] I have performed a self-review of my code.
- [x] No visual design changes; screenshots are not applicable.
- [x] Related issues and changelog requirements considered; none applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved video preview stability when switching media or reopening the editor.
  - Video previews now update more reliably after media loads and resume correctly after being paused or suspended.
  - Improved cleanup when preview videos are detached, reducing stale playback behavior and unnecessary resource usage.

- **Tests**
  - Added coverage for video source reuse, suspension and resumption, media updates, and video element replacement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->