### PR TITLE
docs: explain Linux AppImage FUSE dependency and workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,41 @@ https://github.com/webadderallorg/Recordly/releases
 
 ---
 
+## Linux: AppImage does not open (missing FUSE)
+
+If the AppImage does not open from your file manager, run it from a terminal in the download directory to see the error:
+
+```bash
+chmod +x Recordly-linux-x64.AppImage
+./Recordly-linux-x64.AppImage
+```
+
+If the output includes `dlopen(): error loading libfuse.so.2` or `AppImages require FUSE to run`, install the FUSE 2 library for your distribution. FUSE 3 alone does not provide this library.
+
+**Ubuntu 24.04 / Debian 13:**
+
+```bash
+sudo apt install libfuse2t64
+```
+
+**Ubuntu 22.04 / Debian 12:**
+
+```bash
+sudo apt install libfuse2
+```
+
+Then run the AppImage again. For other distributions, see the [AppImage FUSE troubleshooting guide](https://docs.appimage.org/user-guide/troubleshooting/fuse.html).
+
+If you cannot install FUSE, extract and run the AppImage instead:
+
+```bash
+./Recordly-linux-x64.AppImage --appimage-extract-and-run
+```
+
+This extracts temporary files and removes them when the app closes, so startup can be slower. It bypasses the FUSE dependency; other system requirements still apply.
+
+---
+
 ## Arch Linux / Manjaro (yay)
 
 Install from the AUR ([recordly-bin](https://aur.archlinux.org/packages/recordly-bin)):


### PR DESCRIPTION
## Description

Add a Linux AppImage troubleshooting section to the README with terminal diagnostics, FUSE 2 installation commands for Ubuntu 22.04/24.04 and Debian 12/13, and the `--appimage-extract-and-run` fallback.

## Motivation

When FUSE 2 is missing, launching from a file manager can appear to do nothing. These instructions help users expose the error and resolve the missing dependency, including the renamed `libfuse2t64` package on newer distributions.

## Type of Change

- [x] Documentation Update

## Related Issue(s)

Fixes #818

## Testing Guide

- `git diff --check` passed before committing; reviewed the README diff.
- Confirmed the executable filename against the v1.3.3 release asset.
- Checked the fallback against the [official AppImage guide](https://docs.appimage.org/user-guide/troubleshooting/fuse.html).
- Verified package names in the official [Ubuntu 22.04](https://packages.ubuntu.com/jammy/libfuse2), [Ubuntu 24.04](https://packages.ubuntu.com/noble/libfuse2t64), [Debian 12](https://packages.debian.org/bookworm/libfuse2), and [Debian 13](https://packages.debian.org/trixie/libfuse2t64) catalogs.
- Documentation only; app tests and Linux runtime checks were not run on the macOS development host. On Linux, reviewers can follow the new section with the release AppImage.

## Checklist

- [x] I have performed a self-review of the change.
- [x] I have linked the related issue.
- Screenshots, videos, and a changelog update are not applicable to this documentation change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added troubleshooting guidance for AppImage launch failures caused by missing FUSE support on Linux.
  - Included distribution-specific installation instructions for required FUSE libraries.
  - Documented a command-line workaround for running AppImages without FUSE.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->