### PR TITLE
fix(linux): stop HUD menus being clipped, and show Deutsch instead of "de"

### DIFF
--- a/electron/hudOverlayBounds.test.ts
+++ b/electron/hudOverlayBounds.test.ts
@@ -21,18 +21,26 @@ describe("getHudOverlayWindowBounds", () => {
 	it("uses a bottom-centered compact fallback when mouse passthrough is unavailable", () => {
 		expect(getHudOverlayWindowBounds(workArea, false)).toEqual({
 			x: 650,
-			y: 920,
+			y: 520,
 			width: 860,
-			height: 160,
+			height: 560,
 		});
+	});
+
+	it("reserves enough compact height for a full-height HUD menu", () => {
+		// The menu card is capped at 400px and sits above roughly 96px of bar and
+		// padding plus 16px of offsets. If the compact window is shorter than that
+		// the menu is clipped by the window bounds, which is the bug this guards.
+		const compact = getHudOverlayWindowBounds(workArea, false);
+		expect(compact.height).toBeGreaterThanOrEqual(400 + 16 + 96);
 	});
 
 	it("expands the non-passthrough fallback for HUD menus and hover interaction", () => {
 		expect(getHudOverlayWindowBounds(workArea, false, true)).toEqual({
 			x: 650,
-			y: 540,
+			y: 400,
 			width: 860,
-			height: 540,
+			height: 680,
 		});
 	});
 
@@ -49,9 +57,9 @@ describe("getHudOverlayWindowBounds", () => {
 			),
 		).toEqual({
 			x: -100,
-			y: 280,
+			y: 20,
 			width: 640,
-			height: 160,
+			height: 420,
 		});
 	});
 
@@ -98,9 +106,9 @@ describe("resizeHudOverlayFallbackBounds", () => {
 			),
 		).toEqual({
 			x: 420,
-			y: 320,
+			y: 180,
 			width: 860,
-			height: 540,
+			height: 680,
 		});
 	});
 
@@ -110,17 +118,17 @@ describe("resizeHudOverlayFallbackBounds", () => {
 				workArea,
 				{
 					x: 420,
-					y: 320,
+					y: 180,
 					width: 860,
-					height: 540,
+					height: 680,
 				},
 				false,
 			),
 		).toEqual({
 			x: 420,
-			y: 700,
+			y: 300,
 			width: 860,
-			height: 160,
+			height: 560,
 		});
 	});
 
@@ -138,9 +146,9 @@ describe("resizeHudOverlayFallbackBounds", () => {
 			),
 		).toEqual({
 			x: 1060,
-			y: 520,
+			y: 380,
 			width: 860,
-			height: 540,
+			height: 680,
 		});
 	});
 });

--- a/electron/hudOverlayBounds.ts
+++ b/electron/hudOverlayBounds.ts
@@ -6,8 +6,18 @@ export interface HudOverlayWorkArea {
 }
 
 const NON_PASSTHROUGH_HUD_WIDTH_DIP = 860;
-const NON_PASSTHROUGH_HUD_COMPACT_HEIGHT_DIP = 160;
-const NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP = 540;
+// Without mouse passthrough the HUD is an ordinary window, so anything the
+// renderer draws outside it is clipped: a menu taller than the window loses its
+// top rows. Resizing on demand is not an option either, because Wayland
+// compositors ignore client-side moves, so a window that grows keeps its
+// top-left pinned and drags the bar down with it.
+//
+// So reserve the menu headroom once, at creation. The bar renders at the bottom
+// edge of the window, which leaves the space above it transparent and free for
+// menus to open into without the window ever changing size.
+// 400px menu card + 16px offsets + ~96px of bar and padding, rounded up.
+const NON_PASSTHROUGH_HUD_COMPACT_HEIGHT_DIP = 560;
+const NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP = 680;
 
 function clamp(value: number, min: number, max: number): number {
 	return Math.min(Math.max(value, min), max);

--- a/electron/windows.ts
+++ b/electron/windows.ts
@@ -5,11 +5,7 @@ import { fileURLToPath } from "node:url";
 import { app, BrowserWindow, ipcMain } from "electron";
 import { supportsHudCaptureProtection } from "../src/lib/hudCaptureProtection";
 import { USER_DATA_PATH } from "./appPaths";
-import {
-	getHudOverlayWindowBounds,
-	resizeHudOverlayFallbackBounds,
-	shouldExpandHudOverlayFallback,
-} from "./hudOverlayBounds";
+import { getHudOverlayWindowBounds, shouldExpandHudOverlayFallback } from "./hudOverlayBounds";
 import { getHudOverlayTaskbarOptions } from "./hudOverlayWindowOptions";
 import { getPackagedRendererBaseUrl } from "./rendererServer";
 
@@ -265,34 +261,6 @@ function positionUpdateToastWindow() {
 	updateToastWindow.moveTop();
 }
 
-function setHudOverlayFallbackExpanded(expanded: boolean) {
-	if (hudOverlayRecordingActive) {
-		hudOverlayFallbackExpanded = false;
-		return;
-	}
-
-	hudOverlayFallbackExpanded = expanded;
-	if (
-		!hudOverlayWindow ||
-		hudOverlayWindow.isDestroyed() ||
-		isHudOverlayMousePassthroughSupported()
-	) {
-		return;
-	}
-
-	const { workArea } = getHudOverlayDisplay();
-	const nextBounds = resizeHudOverlayFallbackBounds(
-		workArea,
-		hudOverlayWindow.getBounds(),
-		expanded,
-	);
-	hudOverlayWindow.setBounds(nextBounds, false);
-	positionUpdateToastWindow();
-	if (hudOverlayWindow.isVisible()) {
-		hudOverlayWindow.moveTop();
-	}
-}
-
 function setHudOverlayMousePassthrough(ignore: boolean) {
 	hudOverlayIgnoringMouse =
 		hudOverlaySourceSelectionActive && !hudOverlayRecordingActive ? true : ignore;
@@ -312,9 +280,10 @@ function setHudOverlayMousePassthrough(ignore: boolean) {
 	}
 
 	if (!isHudOverlayMousePassthroughSupported()) {
-		if (process.platform !== "linux") {
-			setHudOverlayFallbackExpanded(!ignore);
-		}
+		// Deliberately no resize here. This branch is Linux-only, and growing the
+		// window on hover moves the bar out from under the pointer, which fires
+		// mouseleave and shrinks it back, oscillating. The fallback window instead
+		// reserves menu headroom up front, so menus need no resize at all.
 		hudOverlayWindow.setIgnoreMouseEvents(false);
 		return;
 	}

--- a/src/components/launch/popovers/MorePopover.tsx
+++ b/src/components/launch/popovers/MorePopover.tsx
@@ -14,24 +14,12 @@ import { useI18n } from "@/contexts/I18nContext";
 import { useScopedT } from "@/contexts/I18nContext";
 import { useTheme } from "@/contexts/ThemeContext";
 import type { AppLocale } from "@/i18n/config";
-import { SUPPORTED_LOCALES } from "@/i18n/config";
+import { LOCALE_LABELS, SUPPORTED_LOCALES } from "@/i18n/config";
 import styles from "../LaunchWindow.module.css";
 import { useLaunchPopoverCoordinator } from "./LaunchPopoverCoordinator";
 import { DropdownItem, HudPopover } from "./PopoverScaffold";
 
 const POPOVER_ID = "more";
-
-const LOCALE_LABELS: Record<string, string> = {
-	en: "English",
-	es: "Español",
-	fr: "Français",
-	it: "Italiano",
-	nl: "Nederlands",
-	ko: "한국어",
-	"pt-BR": "Português",
-	"zh-CN": "簡體中文",
-	"zh-TW": "繁體中文",
-};
 
 export function MorePopover({
 	trigger,
@@ -170,7 +158,7 @@ export function MorePopover({
 						requestClose(POPOVER_ID);
 					}}
 				>
-					{LOCALE_LABELS[code] ?? code}
+					{LOCALE_LABELS[code]}
 				</DropdownItem>
 			))}
 			{appVersion && (

--- a/src/components/video-editor/SettingsPanel.tsx
+++ b/src/components/video-editor/SettingsPanel.tsx
@@ -32,7 +32,7 @@ import {
 import { type AspectRatio } from "@/utils/aspectRatioUtils";
 import { useI18n, useScopedT } from "../../contexts/I18nContext";
 import type { AppLocale } from "../../i18n/config";
-import { SUPPORTED_LOCALES } from "../../i18n/config";
+import { LOCALE_LABELS, SUPPORTED_LOCALES } from "../../i18n/config";
 import { AnnotationSettingsPanel } from "./AnnotationSettingsPanel";
 import CaptionListPanel from "./CaptionListPanel";
 import type { CaptionRetimeSpan } from "./captionOps";
@@ -706,19 +706,6 @@ const CAPTION_LANGUAGE_OPTIONS = [
 	{ value: "ja", label: "Japanese" },
 	{ value: "ko", label: "Korean" },
 ] as const;
-
-const APP_LANGUAGE_LABELS: Record<AppLocale, string> = {
-	en: "English",
-	es: "Español",
-	fr: "Français",
-	de: "Deutsch",
-	it: "Italiano",
-	nl: "Nederlands",
-	ko: "한국어",
-	"pt-BR": "Português",
-	"zh-CN": "簡體中文",
-	"zh-TW": "繁體中文",
-};
 
 function loadPreviewImage(url: string) {
 	return new Promise<HTMLImageElement>((resolve, reject) => {
@@ -2575,7 +2562,7 @@ export function SettingsPanel({
 						<SelectContent className="border-foreground/10 bg-editor-surface-alt text-foreground">
 							{SUPPORTED_LOCALES.map((candidateLocale) => (
 								<SelectItem key={candidateLocale} value={candidateLocale}>
-									{APP_LANGUAGE_LABELS[candidateLocale]}
+									{LOCALE_LABELS[candidateLocale]}
 								</SelectItem>
 							))}
 						</SelectContent>

--- a/src/i18n/config.ts
+++ b/src/i18n/config.ts
@@ -25,3 +25,21 @@ export const I18N_NAMESPACES = [
 
 export type AppLocale = (typeof SUPPORTED_LOCALES)[number];
 export type I18nNamespace = (typeof I18N_NAMESPACES)[number];
+
+/**
+ * Native display name per locale. Typed against AppLocale so adding a locale to
+ * SUPPORTED_LOCALES without a label is a compile error rather than a menu row
+ * that renders the raw locale code.
+ */
+export const LOCALE_LABELS: Record<AppLocale, string> = {
+	en: "English",
+	es: "Español",
+	fr: "Français",
+	de: "Deutsch",
+	it: "Italiano",
+	nl: "Nederlands",
+	ko: "한국어",
+	"pt-BR": "Português",
+	"zh-CN": "簡體中文",
+	"zh-TW": "繁體中文",
+};


### PR DESCRIPTION
Hit this on Ubuntu 24.04 / GNOME 46 under Wayland: opening the More menu on the recording HUD only shows the bottom couple of rows, everything above is cut off. Same menu also lists German as "de" rather than "Deutsch".

The clipping is a window bounds problem. With no mouse passthrough the HUD is a plain 860x160 window and the popovers render inside it, so a menu taller than the window just gets cut. The More menu needs roughly 510px with ten locales and there's about 150px of room.

There is already code to grow the window for exactly this, but the call sits behind `process.platform !== "linux"` inside a branch you only reach when `isHudOverlayMousePassthroughSupported()` is false, which is `platform === "linux"`. So it can never run, and `NON_PASSTHROUGH_HUD_EXPANDED_HEIGHT_DIP` was doing nothing.

Deleting that guard is the obvious fix and it's wrong. Growing on hover shifts the bar out from under the cursor, that fires mouseleave, the window shrinks, the bar lands back under the cursor, repeat. That's #891. Wayland makes it worse because compositors ignore client-side moves, so a window that grows keeps its top-left pinned and extends downward, dragging the bar with it. Worth knowing if you go looking: after `setBounds`, `getBounds()` still reports the bottom-anchored position you asked for while the bar visibly slides down, so the main process can't tell the reposition was refused.

So I stopped resizing for menus at all and reserved the room up front instead, 160 to 560 (a 400px menu card, ~16px of offsets, ~96px of bar and padding). The bar renders at the bottom edge of the window so it stays put, and the space above it is transparent and already free for the menu to open into. Nothing resizes, so nothing moves, on X11 or Wayland. I bumped the expanded height used by the webcam preview from 540 to 680 so it still adds room on top of the new baseline, and `setHudOverlayFallbackExpanded` lost its last caller so it's gone.

The locale label is unrelated but it's the same menu. `MorePopover` had its own `Record<string, string>` map with no `de` entry, while `SettingsPanel` had a near-identical map that did have it. Merged them into one `LOCALE_LABELS` in `src/i18n/config.ts` typed `Record<AppLocale, string>`, so a missing label is a build error now instead of a row that prints its own locale code.

One trade-off to call out: the fallback window is transparent but still swallows clicks on Linux (#861), and a 560px tall one swallows more than a 160px one. I'd take that over the bar jumping on every Wayland setup, but say so if you disagree. The real answer is passthrough on Linux, which is #861 and not this PR.

tsc, biome lint and format, and i18n:check are all clean, full vitest run is 1084 passing, and I added a test that fails if the compact height ever drops below what a full-height menu needs so this can't quietly come back. Checked by hand on GNOME 46 Wayland.

Also, #876, #863, #799 and #705 all touch HUD popover clipping on Linux. #876 in particular solves this with a menu-open IPC signal plus a Wayland resize anchor; this is just the smaller "don't resize at all" version. Happy to close it if you'd rather take that one.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved HUD overlay sizing for compact and expanded states, providing sufficient space for the full menu.
  - Prevented hover-related HUD window resizing and visual oscillation on Linux.

- **Improvements**
  - Standardized language names across settings and menu interfaces.
  - Updated Simplified Chinese to display using the correct native label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->