### PR TITLE
fix: avoid Linux WebGPU export failures

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -585,6 +585,7 @@ interface Window {
 		onRecordingStateChanged: (
 			callback: (state: { recording: boolean; sourceName: string }) => void,
 		) => () => void;
+		onRecordingTogglePause: (callback: () => void) => () => void;
 		onRecordingSessionChanged: (
 			callback: (session: RendererRecordingSessionData | null) => void,
 		) => () => void;

--- a/electron/ipc/cursor/interaction.test.ts
+++ b/electron/ipc/cursor/interaction.test.ts
@@ -12,9 +12,30 @@ vi.mock("electron", () => ({
 }));
 
 import {
+	getHookKeyboardKey,
+	matchesHookKeyboardShortcut,
 	repairBundledUiohookBinaryForCurrentArch,
 	shouldStartGlobalInteractionHook,
 } from "./interaction";
+
+describe("global keyboard shortcut matching", () => {
+	it("normalizes the space key used by the default Play / Pause shortcut", () => {
+		expect(getHookKeyboardKey({ keycode: 0x0039 })).toBe(" ");
+		expect(matchesHookKeyboardShortcut({ keycode: 0x0039 }, { key: " " }, false)).toBe(true);
+	});
+
+	it("honors platform-aware modifiers", () => {
+		const binding = { key: "p", ctrl: true };
+
+		expect(
+			matchesHookKeyboardShortcut({ keycode: 0x0019, ctrlKey: true }, binding, false),
+		).toBe(true);
+		expect(matchesHookKeyboardShortcut({ keycode: 0x0019, metaKey: true }, binding, true)).toBe(
+			true,
+		);
+		expect(matchesHookKeyboardShortcut({ keycode: 0x0019 }, binding, false)).toBe(false);
+	});
+});
 
 describe("shouldStartGlobalInteractionHook", () => {
 	it("does not start the synchronous uiohook event tap on macOS", () => {

--- a/electron/ipc/cursor/interaction.ts
+++ b/electron/ipc/cursor/interaction.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs";
 import { createRequire } from "node:module";
 import path from "node:path";
+import type { ShortcutBinding } from "../../../src/lib/shortcuts";
 import {
 	hasLoggedInteractionHookFailure,
 	interactionCaptureCleanup,
@@ -13,6 +14,8 @@ import {
 } from "../state";
 import type {
 	CursorInteractionType,
+	HookKeyboardEvent,
+	HookKeyboardEventListener,
 	HookMouseEvent,
 	UiohookLike,
 	UiohookModuleNamespace,
@@ -47,6 +50,93 @@ export function getHookMouseButton(event: HookMouseEvent | null | undefined): 1 
 	return normalizeHookMouseButton(
 		event?.button ?? event?.mouseButton ?? event?.data?.button ?? event?.data?.mouseButton,
 	);
+}
+
+const UIOHOOK_KEY_TO_EVENT_KEY = new Map<number, string>([
+	[0x0001, "escape"],
+	[0x000e, "backspace"],
+	[0x000f, "tab"],
+	[0x001c, "enter"],
+	[0x0039, " "],
+	[0x0e49, "pageup"],
+	[0x0e51, "pagedown"],
+	[0x0e4f, "end"],
+	[0x0e47, "home"],
+	[0xe04b, "arrowleft"],
+	[0xe048, "arrowup"],
+	[0xe04d, "arrowright"],
+	[0xe050, "arrowdown"],
+	[0x0e52, "insert"],
+	[0x0e53, "delete"],
+	[0x000b, "0"],
+	[0x0002, "1"],
+	[0x0003, "2"],
+	[0x0004, "3"],
+	[0x0005, "4"],
+	[0x0006, "5"],
+	[0x0007, "6"],
+	[0x0008, "7"],
+	[0x0009, "8"],
+	[0x000a, "9"],
+	[0x001e, "a"],
+	[0x0030, "b"],
+	[0x002e, "c"],
+	[0x0020, "d"],
+	[0x0012, "e"],
+	[0x0021, "f"],
+	[0x0022, "g"],
+	[0x0023, "h"],
+	[0x0017, "i"],
+	[0x0024, "j"],
+	[0x0025, "k"],
+	[0x0026, "l"],
+	[0x0032, "m"],
+	[0x0031, "n"],
+	[0x0018, "o"],
+	[0x0019, "p"],
+	[0x0010, "q"],
+	[0x0013, "r"],
+	[0x001f, "s"],
+	[0x0014, "t"],
+	[0x0016, "u"],
+	[0x002f, "v"],
+	[0x0011, "w"],
+	[0x002d, "x"],
+	[0x0015, "y"],
+	[0x002c, "z"],
+	[0x003b, "f1"],
+	[0x003c, "f2"],
+	[0x003d, "f3"],
+	[0x003e, "f4"],
+	[0x003f, "f5"],
+	[0x0040, "f6"],
+	[0x0041, "f7"],
+	[0x0042, "f8"],
+	[0x0043, "f9"],
+	[0x0044, "f10"],
+	[0x0057, "f11"],
+	[0x0058, "f12"],
+]);
+
+export function getHookKeyboardKey(event: HookKeyboardEvent | null | undefined): string | null {
+	if (typeof event?.keycode !== "number") return null;
+	return UIOHOOK_KEY_TO_EVENT_KEY.get(event.keycode) ?? null;
+}
+
+export function matchesHookKeyboardShortcut(
+	event: HookKeyboardEvent,
+	binding: ShortcutBinding,
+	isMacPlatform: boolean,
+): boolean {
+	const key = getHookKeyboardKey(event);
+	if (!key || key !== binding.key.toLowerCase()) return false;
+
+	const primaryMod = isMacPlatform ? event.metaKey : event.ctrlKey;
+	if (!!primaryMod !== !!binding.ctrl) return false;
+	if (!!event.shiftKey !== !!binding.shift) return false;
+	if (!!event.altKey !== !!binding.alt) return false;
+
+	return true;
 }
 
 export function stopInteractionCapture() {
@@ -233,7 +323,9 @@ export function recordCursorMouseUp() {
 	pushCursorSample(point.cx, point.cy, getCursorCaptureElapsedMs(), "mouseup");
 }
 
-export async function startInteractionCapture() {
+export async function startInteractionCapture(
+	options: { onKeyDown?: HookKeyboardEventListener; onKeyUp?: HookKeyboardEventListener } = {},
+) {
 	if (!isCursorCaptureActive) {
 		return;
 	}
@@ -276,6 +368,14 @@ export async function startInteractionCapture() {
 			recordCursorMouseUp();
 		};
 
+		const onKeyDown = (event: HookKeyboardEvent) => {
+			options.onKeyDown?.(event);
+		};
+
+		const onKeyUp = (event: HookKeyboardEvent) => {
+			options.onKeyUp?.(event);
+		};
+
 		const onMouseMove = (event: HookMouseEvent) => {
 			if (process.platform !== "linux" || !isCursorCaptureActive || isCursorCapturePaused()) {
 				return;
@@ -291,6 +391,12 @@ export async function startInteractionCapture() {
 
 		hook.on("mousedown", onMouseDown);
 		hook.on("mouseup", onMouseUp);
+		if (options.onKeyDown) {
+			hook.on("keydown", onKeyDown);
+		}
+		if (options.onKeyUp) {
+			hook.on("keyup", onKeyUp);
+		}
 		if (process.platform === "linux") {
 			hook.on("mousemove", onMouseMove);
 		}
@@ -300,12 +406,24 @@ export async function startInteractionCapture() {
 				if (typeof hook.off === "function") {
 					hook.off("mousedown", onMouseDown);
 					hook.off("mouseup", onMouseUp);
+					if (options.onKeyDown) {
+						hook.off("keydown", onKeyDown);
+					}
+					if (options.onKeyUp) {
+						hook.off("keyup", onKeyUp);
+					}
 					if (process.platform === "linux") {
 						hook.off("mousemove", onMouseMove);
 					}
 				} else if (typeof hook.removeListener === "function") {
 					hook.removeListener("mousedown", onMouseDown);
 					hook.removeListener("mouseup", onMouseUp);
+					if (options.onKeyDown) {
+						hook.removeListener("keydown", onKeyDown);
+					}
+					if (options.onKeyUp) {
+						hook.removeListener("keyup", onKeyUp);
+					}
 					if (process.platform === "linux") {
 						hook.removeListener("mousemove", onMouseMove);
 					}

--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -1,5 +1,6 @@
 import type { ChildProcessWithoutNullStreams } from "node:child_process";
 import { execFile, spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
@@ -13,14 +14,19 @@ import {
 	systemPreferences,
 } from "electron";
 import { getHudCaptureExcludedProcessIds } from "../../../src/lib/hudCaptureProtection";
+import { DEFAULT_SHORTCUTS, type ShortcutBinding } from "../../../src/lib/shortcuts";
 import { showCursor } from "../../cursorHider";
 import {
 	getHudOverlayCaptureProtectionEnabled,
 	reassertHudOverlayCaptureProtection,
 } from "../../windows";
-import { ALLOW_RECORDLY_WINDOW_CAPTURE } from "../constants";
+import { ALLOW_RECORDLY_WINDOW_CAPTURE, SHORTCUTS_FILE } from "../constants";
 import { startWindowBoundsCapture, stopWindowBoundsCapture } from "../cursor/bounds";
-import { startInteractionCapture, stopInteractionCapture } from "../cursor/interaction";
+import {
+	matchesHookKeyboardShortcut,
+	startInteractionCapture,
+	stopInteractionCapture,
+} from "../cursor/interaction";
 import { startNativeCursorMonitor, stopNativeCursorMonitor } from "../cursor/monitor";
 import {
 	normalizeCursorTelemetrySamples,
@@ -143,7 +149,12 @@ import {
 	windowsPendingVideoPath,
 	windowsSystemAudioPath,
 } from "../state";
-import type { CursorTelemetryPoint, NativeMacRecordingOptions, SelectedSource } from "../types";
+import type {
+	CursorTelemetryPoint,
+	HookKeyboardEvent,
+	NativeMacRecordingOptions,
+	SelectedSource,
+} from "../types";
 import {
 	getMacPrivacySettingsUrl,
 	getRecordingsDir,
@@ -401,6 +412,61 @@ async function resolveExistingPath(...candidates: Array<string | null | undefine
 export function registerRecordingHandlers(
 	onRecordingStateChange?: (recording: boolean, sourceName: string) => void,
 ) {
+	let recordingPauseShortcut: ShortcutBinding = DEFAULT_SHORTCUTS.playPause;
+	const pressedRecordingShortcutKeycodes = new Set<number>();
+
+	const loadRecordingPauseShortcut = () => {
+		try {
+			const parsed = JSON.parse(readFileSync(SHORTCUTS_FILE, "utf-8")) as {
+				playPause?: Partial<ShortcutBinding>;
+			};
+			const binding = parsed.playPause;
+			if (typeof binding?.key === "string" && binding.key.length > 0) {
+				recordingPauseShortcut = {
+					key: binding.key,
+					ctrl: binding.ctrl === true,
+					shift: binding.shift === true,
+					alt: binding.alt === true,
+				};
+				return;
+			}
+		} catch {
+			// Use the editor's default Play / Pause binding when no settings exist.
+		}
+
+		recordingPauseShortcut = DEFAULT_SHORTCUTS.playPause;
+	};
+
+	const handleRecordingShortcutKeyDown = (event: HookKeyboardEvent) => {
+		const keycode = event.keycode;
+		if (
+			typeof keycode !== "number" ||
+			!matchesHookKeyboardShortcut(
+				event,
+				recordingPauseShortcut,
+				process.platform === "darwin",
+			)
+		) {
+			return;
+		}
+
+		// uiohook can repeat keydown events while a key is held. Toggle once per press.
+		if (pressedRecordingShortcutKeycodes.has(keycode)) return;
+		pressedRecordingShortcutKeycodes.add(keycode);
+
+		BrowserWindow.getAllWindows().forEach((window) => {
+			if (!window.isDestroyed()) {
+				window.webContents.send("recording-toggle-pause");
+			}
+		});
+	};
+
+	const handleRecordingShortcutKeyUp = (event: HookKeyboardEvent) => {
+		if (typeof event.keycode === "number") {
+			pressedRecordingShortcutKeycodes.delete(event.keycode);
+		}
+	};
+
 	ipcMain.handle(
 		"start-native-screen-recording",
 		async (_, source: SelectedSource, options?: NativeMacRecordingOptions) => {
@@ -1862,6 +1928,8 @@ export function registerRecordingHandlers(
 
 	ipcMain.handle("set-recording-state", (_, recording: boolean) => {
 		if (recording) {
+			loadRecordingPauseShortcut();
+			pressedRecordingShortcutKeycodes.clear();
 			stopCursorCapture();
 			stopInteractionCapture();
 			startWindowBoundsCapture();
@@ -1875,8 +1943,12 @@ export function registerRecordingHandlers(
 			setLastLeftClick(null);
 			sampleCursorPoint();
 			startCursorSampling();
-			void startInteractionCapture();
+			void startInteractionCapture({
+				onKeyDown: handleRecordingShortcutKeyDown,
+				onKeyUp: handleRecordingShortcutKeyUp,
+			});
 		} else {
+			pressedRecordingShortcutKeycodes.clear();
 			setIsCursorCaptureActive(false);
 			stopCursorCapture();
 			stopInteractionCapture();

--- a/electron/ipc/types.ts
+++ b/electron/ipc/types.ts
@@ -122,6 +122,14 @@ export type NativeMacWindowSource = {
 
 export type HookEventName = "mousedown" | "mouseup" | "mousemove";
 
+export type HookKeyboardEvent = {
+	altKey?: boolean;
+	ctrlKey?: boolean;
+	metaKey?: boolean;
+	shiftKey?: boolean;
+	keycode?: number;
+};
+
 export type HookMouseEvent = {
 	button?: number;
 	mouseButton?: number;
@@ -140,11 +148,21 @@ export type HookMouseEvent = {
 };
 
 export type HookEventListener = (event: HookMouseEvent) => void;
+export type HookKeyboardEventListener = (event: HookKeyboardEvent) => void;
 
 export type UiohookLike = {
-	on: (eventName: HookEventName, listener: HookEventListener) => void;
-	off?: (eventName: HookEventName, listener: HookEventListener) => void;
-	removeListener?: (eventName: HookEventName, listener: HookEventListener) => void;
+	on: {
+		(eventName: HookEventName, listener: HookEventListener): void;
+		(eventName: "keydown" | "keyup", listener: HookKeyboardEventListener): void;
+	};
+	off?: {
+		(eventName: HookEventName, listener: HookEventListener): void;
+		(eventName: "keydown" | "keyup", listener: HookKeyboardEventListener): void;
+	};
+	removeListener?: {
+		(eventName: HookEventName, listener: HookEventListener): void;
+		(eventName: "keydown" | "keyup", listener: HookKeyboardEventListener): void;
+	};
 	start: () => void;
 	stop?: () => void;
 };

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -605,6 +605,11 @@ contextBridge.exposeInMainWorld("electronAPI", {
 		ipcRenderer.on("recording-state-changed", listener);
 		return () => ipcRenderer.removeListener("recording-state-changed", listener);
 	},
+	onRecordingTogglePause: (callback: () => void) => {
+		const listener = () => callback();
+		ipcRenderer.on("recording-toggle-pause", listener);
+		return () => ipcRenderer.removeListener("recording-toggle-pause", listener);
+	},
 	onRecordingInterrupted: (callback: (state: { reason: string; message: string }) => void) => {
 		const listener = (
 			_event: Electron.IpcRendererEvent,

--- a/src/components/launch/LaunchWindow.tsx
+++ b/src/components/launch/LaunchWindow.tsx
@@ -158,6 +158,14 @@ function LaunchWindowContent() {
 	}, [showRecordingWebcamPreview]);
 
 	useEffect(() => {
+		return window.electronAPI?.onRecordingTogglePause?.(() => {
+			if (!recording) return;
+			if (paused) resumeRecording();
+			else pauseRecording();
+		});
+	}, [pauseRecording, paused, recording, resumeRecording]);
+
+	useEffect(() => {
 		return () => {
 			window.electronAPI?.hudOverlaySetWebcamPreviewVisible?.(false);
 		};

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -266,6 +266,14 @@ function isCanvasRenderer(application: Application): boolean {
 	);
 }
 
+function isLinuxRuntime(): boolean {
+	if (typeof navigator === "undefined") {
+		return false;
+	}
+
+	return /linux/i.test(navigator.platform || navigator.userAgent || "");
+}
+
 function toErrorMessage(error: unknown): string {
 	return error instanceof Error ? error.message : String(error ?? "Unknown renderer init error");
 }
@@ -451,12 +459,6 @@ export class FrameRenderer {
 	private webcamLayoutCache: WebcamLayoutCache | null = null;
 	private videoTextureUsesStartupStaging = false;
 	private webcamTextureUsesStartupStaging = false;
-	private retainedSceneSourceFrame: VideoFrame | null = null;
-	private retainedSceneTextureFrame: VideoFrame | null = null;
-	private retainedBackgroundSourceFrame: VideoFrame | null = null;
-	private retainedBackgroundTextureFrame: VideoFrame | null = null;
-	private retainedWebcamSourceFrame: VideoFrame | null = null;
-	private retainedWebcamTextureFrame: VideoFrame | null = null;
 	private retainedSceneBitmapTimestamp: number | null = null;
 	private retainedSceneBitmap: ImageBitmap | null = null;
 	private retainedBackgroundBitmapTimestamp: number | null = null;
@@ -640,14 +642,16 @@ export class FrameRenderer {
 		};
 
 		const preferredRenderBackend = this.config.preferredRenderBackend;
+		const shouldPreferWebGpuByDefault =
+			!isLinuxRuntime() && typeof navigator !== "undefined" && "gpu" in navigator;
 		const backendOrder: ExportRenderBackend[] =
 			preferredRenderBackend === "webgl"
 				? ["webgl", "webgpu"]
 				: preferredRenderBackend === "webgpu"
 					? ["webgpu", "webgl"]
-					: typeof navigator !== "undefined" && "gpu" in navigator
+					: shouldPreferWebGpuByDefault
 						? ["webgpu", "webgl"]
-						: ["webgl"];
+						: ["webgl", "webgpu"];
 		const failures: PixiRendererAttempt[] = [];
 
 		for (const backend of backendOrder) {
@@ -814,59 +818,6 @@ export class FrameRenderer {
 		layer.container.visible = true;
 	}
 
-	private getRetainedVideoFrameState(kind: "scene" | "background" | "webcam") {
-		if (kind === "scene") {
-			return {
-				sourceFrame: this.retainedSceneSourceFrame,
-				textureFrame: this.retainedSceneTextureFrame,
-			};
-		}
-
-		if (kind === "background") {
-			return {
-				sourceFrame: this.retainedBackgroundSourceFrame,
-				textureFrame: this.retainedBackgroundTextureFrame,
-			};
-		}
-
-		return {
-			sourceFrame: this.retainedWebcamSourceFrame,
-			textureFrame: this.retainedWebcamTextureFrame,
-		};
-	}
-
-	private setRetainedVideoFrameState(
-		kind: "scene" | "background" | "webcam",
-		sourceFrame: VideoFrame | null,
-		textureFrame: VideoFrame | null,
-	): void {
-		if (kind === "scene") {
-			this.retainedSceneSourceFrame = sourceFrame;
-			this.retainedSceneTextureFrame = textureFrame;
-			return;
-		}
-
-		if (kind === "background") {
-			this.retainedBackgroundSourceFrame = sourceFrame;
-			this.retainedBackgroundTextureFrame = textureFrame;
-			return;
-		}
-
-		this.retainedWebcamSourceFrame = sourceFrame;
-		this.retainedWebcamTextureFrame = textureFrame;
-	}
-
-	private closeRetainedVideoFrame(kind: "scene" | "background" | "webcam"): void {
-		const state = this.getRetainedVideoFrameState(kind);
-		if (!state.textureFrame) {
-			this.setRetainedVideoFrameState(kind, null, null);
-			return;
-		}
-
-		state.textureFrame.close();
-		this.setRetainedVideoFrameState(kind, null, null);
-	}
-
 	private closeRetainedBitmap(kind: "scene" | "background"): void {
 		if (kind === "scene") {
 			this.retainedSceneBitmap?.close();
@@ -917,37 +868,6 @@ export class FrameRenderer {
 				error,
 			);
 			return this.stageVideoFrameForTexture(frame, kind, fallbackWidth, fallbackHeight);
-		}
-	}
-
-	private resolveRetainedVideoFrameSource(
-		frame: VideoFrame,
-		kind: "scene" | "background" | "webcam",
-		fallbackWidth: number,
-		fallbackHeight: number,
-	): CanvasImageSource | VideoFrame {
-		if (this.rendererBackend !== "webgpu") {
-			return frame;
-		}
-
-		const state = this.getRetainedVideoFrameState(kind);
-		if (state.sourceFrame === frame && state.textureFrame) {
-			return state.textureFrame;
-		}
-
-		try {
-			const retainedFrame = new VideoFrame(frame, {
-				timestamp: frame.timestamp,
-			});
-			this.closeRetainedVideoFrame(kind);
-			this.setRetainedVideoFrameState(kind, frame, retainedFrame);
-			return retainedFrame;
-		} catch (error) {
-			console.warn(
-				`[ModernFrameRenderer] Failed to retain ${kind} VideoFrame, falling back to staging canvas:`,
-				error,
-			);
-			return this.stageVideoFrameOnCanvas(frame, kind, fallbackWidth, fallbackHeight);
 		}
 	}
 
@@ -1028,17 +948,12 @@ export class FrameRenderer {
 		fallbackWidth: number,
 		fallbackHeight: number,
 	): CanvasImageSource | VideoFrame {
-		// Keep webcam uploads on the older canvas-staged path. The newer
-		// retained-VideoFrame upload path is fine for the main scene/background,
-		// but it has produced unstable webcam overlays in Lightning exports.
-		if (kind === "webcam") {
-			return this.stageVideoFrameOnCanvas(frame, kind, fallbackWidth, fallbackHeight);
-		}
-
-		if (this.rendererBackend === "webgpu") {
-			return this.resolveRetainedVideoFrameSource(frame, kind, fallbackWidth, fallbackHeight);
-		}
-
+		// Chromium's Linux WebGPU implementation can expose a VideoFrame that
+		// Pixi accepts as a texture source but cannot bind during rendering. The
+		// resulting failure is the opaque "Cannot read properties of undefined
+		// (reading '_resourceType')" error. Canvas staging is a little less
+		// efficient, but it is portable across WebGPU/WebGL and keeps export
+		// deterministic on Linux.
 		return this.stageVideoFrameOnCanvas(frame, kind, fallbackWidth, fallbackHeight);
 	}
 
@@ -3597,9 +3512,6 @@ export class FrameRenderer {
 		this.webcamVideoFrameStagingCtx = null;
 		this.videoTextureUsesStartupStaging = false;
 		this.webcamTextureUsesStartupStaging = false;
-		this.closeRetainedVideoFrame("scene");
-		this.closeRetainedVideoFrame("background");
-		this.closeRetainedVideoFrame("webcam");
 		this.closeRetainedBitmap("scene");
 		this.closeRetainedBitmap("background");
 


### PR DESCRIPTION
## Summary
- prefer WebGL for Linux exports when the backend is automatic
- stage VideoFrame uploads through canvas to avoid Pixi WebGPU _resourceType failures
- preserve explicit WebGPU selection for users who opt into it
## Verification
- npm test — 1,083 tests passed
- npx tsc --noEmit
- npm run build:linux

 The Linux WebGPU failure was caused by Electron requesting a device with a 16-texture per-stage limit while Pixi generated a 32-texture batch pipeline; the _resourceType exception was a downstream symptom.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable keyboard shortcuts for pausing and resuming active recordings.
  - Shortcut matching now supports platform-specific modifier keys and the default Play/Pause shortcut.

- **Bug Fixes**
  - Improved video export frame handling for scenes, backgrounds, and webcam footage.
  - Linux exports now default to WebGL, while other platforms continue to default to WebGPU.
  - Improved frame cleanup during export to support more reliable rendering across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->