### PR TITLE
fix(linux): retry Lightning export with WebGL fallback when WebGPU render fails

### DIFF
--- a/electron/electron-env.d.ts
+++ b/electron/electron-env.d.ts
@@ -839,6 +839,7 @@ interface Window {
 		onMenuSaveProject: (callback: () => void) => () => void;
 		onMenuSaveProjectAs: (callback: () => void) => () => void;
 		getPlatform: () => Promise<string>;
+		getLinuxRenderBackendEnv: () => Promise<string | null>;
 		getLinuxWindowSystem: () => Promise<"wayland" | "x11" | null>;
 		revealInFolder: (
 			filePath: string,

--- a/electron/ipc/register/settings.ts
+++ b/electron/ipc/register/settings.ts
@@ -51,6 +51,12 @@ export function registerSettingsHandlers() {
 		return process.platform;
 	});
 
+	// Experimental (Linux only): exposes RECORDLY_LINUX_RENDER_BACKEND to the
+	// renderer so the Lightning export can honor webgl|webgpu for validation.
+	ipcMain.handle("get-linux-render-backend-env", () => {
+		return process.env.RECORDLY_LINUX_RENDER_BACKEND ?? null;
+	});
+
 	ipcMain.on("app-settings:get", (event, key: unknown) => {
 		try {
 			if (typeof key !== "string" || key.length === 0) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -916,6 +916,9 @@ contextBridge.exposeInMainWorld("electronAPI", {
 	getPlatform: () => {
 		return ipcRenderer.invoke("get-platform");
 	},
+	getLinuxRenderBackendEnv: () => {
+		return ipcRenderer.invoke("get-linux-render-backend-env");
+	},
 	getLinuxWindowSystem: () => {
 		return ipcRenderer.invoke("get-linux-window-system");
 	},

--- a/scripts/verify-smoke-build.mjs
+++ b/scripts/verify-smoke-build.mjs
@@ -1,0 +1,71 @@
+// Verifies that a packaged Recordly build actually contains the fixes that a
+// smoke run is supposed to validate. A stale dist/ (built from pre-commit
+// sources) once invalidated an entire validation round: the smoke executed,
+// crashed with the exact bug the fix targeted, and the report was mistaken
+// for "the fix does not work".
+//
+// Usage:
+//   node scripts/verify-smoke-build.mjs \
+//     --asar release/linux-unpacked/resources/app.asar \
+//     --expect "RECORDLY_LINUX_RENDER_BACKEND" \
+//     --expect "[smoke-export] Export run started" \
+//     --expect "[VideoExporter] Using" \
+//     --expect "retrying with webgl fallback"
+//
+// Exit codes: 0 = all markers found, 1 = missing markers, 2 = asar unreadable.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+
+export const defaultAsarPath = "release/linux-unpacked/resources/app.asar";
+
+export function parseVerifyArgs(argv) {
+	const { values } = parseArgs({
+		args: argv,
+		options: {
+			asar: { type: "string" },
+			expect: { type: "string", multiple: true },
+		},
+	});
+	const markers = (values.expect ?? []).filter((marker) => marker.length > 0);
+	if (markers.length === 0) {
+		throw new Error("At least one --expect <marker> is required.");
+	}
+	return { asarPath: values.asar ?? defaultAsarPath, markers };
+}
+
+// The asar payload mixes text bundles with native binaries, so read it as
+// latin1 (byte-preserving) instead of utf8: invalid utf8 sequences would be
+// replaced and could swallow ASCII markers at the boundary.
+export function collectMissingMarkers(haystack, markers) {
+	return markers.filter((marker) => !haystack.includes(marker));
+}
+
+function main() {
+	const { asarPath, markers } = parseVerifyArgs(process.argv.slice(2));
+	let payload;
+	try {
+		payload = readFileSync(asarPath, "latin1");
+	} catch (error) {
+		console.error(`[verify-smoke-build] Cannot read ${asarPath}: ${error.message}`);
+		process.exit(2);
+	}
+	const missing = collectMissingMarkers(payload, markers);
+	if (missing.length > 0) {
+		console.error("[verify-smoke-build] FAIL — build is missing expected markers:");
+		for (const marker of missing) {
+			console.error(`  - ${JSON.stringify(marker)}`);
+		}
+		console.error(
+			"The packaged build does not contain the expected fixes. Rebuild (npm run build) before validating.",
+		);
+		process.exit(1);
+	}
+	console.log(`[verify-smoke-build] OK — ${markers.length} marker(s) present in ${asarPath}`);
+}
+
+const isDirectRun = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isDirectRun) {
+	main();
+}

--- a/scripts/verify-smoke-build.test.mjs
+++ b/scripts/verify-smoke-build.test.mjs
@@ -1,0 +1,83 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { collectMissingMarkers, defaultAsarPath, parseVerifyArgs } from "./verify-smoke-build.mjs";
+
+const tempDirs = [];
+afterAll(() => {
+	for (const dir of tempDirs) rmSync(dir, { recursive: true, force: true });
+});
+
+function writeFixture(name, bytes) {
+	const dir = mkdtempSync(join(tmpdir(), "verify-smoke-build-"));
+	tempDirs.push(dir);
+	const filePath = join(dir, name);
+	writeFileSync(filePath, bytes, "latin1");
+	return filePath;
+}
+
+describe("collectMissingMarkers", () => {
+	it("returns an empty list when every marker is present", () => {
+		const haystack =
+			'console.log("[FrameRenderer] Deferred sprite texture retirement active");RECORDLY_LINUX_RENDER_BACKEND';
+		expect(
+			collectMissingMarkers(haystack, [
+				"Deferred sprite texture retirement",
+				"RECORDLY_LINUX_RENDER_BACKEND",
+			]),
+		).toEqual([]);
+	});
+
+	it("reports only the missing markers", () => {
+		const haystack = "RECORDLY_LINUX_RENDER_BACKEND=webgl";
+		expect(
+			collectMissingMarkers(haystack, [
+				"RECORDLY_LINUX_RENDER_BACKEND",
+				"Deferred sprite texture retirement",
+				"[VideoExporter] Using",
+			]),
+		).toEqual(["Deferred sprite texture retirement", "[VideoExporter] Using"]);
+	});
+
+	it("keeps binary-safe latin1 bytes searchable (marker adjacent to non-utf8 bytes)", () => {
+		const haystack = `\xFF\xFE\x00prefix \xFF[smoke-export] Export failed\xFF`;
+		expect(collectMissingMarkers(haystack, ["[smoke-export] Export failed"])).toEqual([]);
+	});
+
+	it("returns every marker for an empty payload", () => {
+		expect(collectMissingMarkers("", ["a", "b"])).toEqual(["a", "b"]);
+	});
+});
+
+describe("parseVerifyArgs", () => {
+	it("parses repeated --expect flags and a custom --asar path", () => {
+		const parsed = parseVerifyArgs([
+			"--asar",
+			"/tmp/custom.asar",
+			"--expect",
+			"marker one",
+			"--expect",
+			"marker two",
+		]);
+		expect(parsed.asarPath).toBe("/tmp/custom.asar");
+		expect(parsed.markers).toEqual(["marker one", "marker two"]);
+	});
+
+	it("defaults the asar path to the linux unpacked build", () => {
+		const parsed = parseVerifyArgs(["--expect", "marker"]);
+		expect(parsed.asarPath).toBe(defaultAsarPath);
+		expect(parsed.markers).toEqual(["marker"]);
+	});
+
+	it("fails fast when no marker is requested", () => {
+		expect(() => parseVerifyArgs([])).toThrow(/--expect/);
+	});
+});
+
+describe("writeFixture helper (latin1 round-trip)", () => {
+	it("round-trips non-utf8 bytes so markers stay searchable", () => {
+		const filePath = writeFixture("fixture.asar", `\xFFmarker-bytes\xFF`);
+		expect(readFileSync(filePath, "latin1")).toContain("marker-bytes");
+	});
+});

--- a/src/components/video-editor/export/useExportRunner.ts
+++ b/src/components/video-editor/export/useExportRunner.ts
@@ -3,6 +3,7 @@ import { toast } from "sonner";
 import { getMp4ExportBitrate } from "@/lib/exporter/exportBitrate";
 import { DEFAULT_MP4_CODEC } from "@/lib/exporter/mp4Support";
 import type { ExportSettings } from "@/lib/exporter/types";
+import { keepError, keepLog } from "@/lib/keepConsole";
 import { calculateMp4ExportDimensions } from "../exportDimensions";
 import { resolveMp4ExportRouting } from "../mp4ExportRouting";
 import { resolveMp4ExportSettings } from "../mp4ExportSettings";
@@ -98,6 +99,14 @@ export function useExportRunner(input: ExportRunnerInput) {
 			setExportError(null);
 			clearPendingExportSave();
 			const smokeExportStartedAt = smokeExportConfig.enabled ? performance.now() : null;
+			if (smokeExportConfig.enabled) {
+				keepLog("[smoke-export] Export run started", {
+					format: settings.format,
+					quality: settings.quality,
+					encodingMode: settings.encodingMode,
+					outputPath: smokeExportConfig.outputPath,
+				});
+			}
 
 			let keepExportDialogOpen = false;
 			const wasPlaying = isPlaying;
@@ -185,7 +194,7 @@ export function useExportRunner(input: ExportRunnerInput) {
 							keepExportDialogOpen = true;
 						} else if (saveResult.success && saveResult.path) {
 							if (smokeExportStartedAt !== null) {
-								console.log(
+								keepLog(
 									`[smoke-export] Completed in ${Math.round(performance.now() - smokeExportStartedAt)}ms (${saveResult.path})`,
 								);
 							}
@@ -428,7 +437,7 @@ export function useExportRunner(input: ExportRunnerInput) {
 								});
 							}
 							if (smokeExportStartedAt !== null) {
-								console.log(
+								keepLog(
 									`[smoke-export] Completed in ${Math.round(performance.now() - smokeExportStartedAt)}ms (${saveResult.path})`,
 								);
 							}
@@ -440,6 +449,11 @@ export function useExportRunner(input: ExportRunnerInput) {
 							}
 						} else {
 							if (smokeExportConfig.enabled) {
+								keepError(
+									`[smoke-export] Export save failed after ${smokeExportElapsedMs}ms: ${
+										saveResult.message || "Failed to save video"
+									}`,
+								);
 								await writeSmokeExportReport(smokeExportConfig.outputPath, {
 									success: false,
 									phase: "save",
@@ -472,6 +486,11 @@ export function useExportRunner(input: ExportRunnerInput) {
 						}
 					} else {
 						if (smokeExportConfig.enabled) {
+							keepError(
+								`[smoke-export] Export failed after ${smokeExportElapsedMs}ms (pipeline=${pipelineModel} backend=${backendPreference}): ${
+									result.error || "Export failed"
+								}`,
+							);
 							await writeSmokeExportReport(smokeExportConfig.outputPath, {
 								success: false,
 								phase: "export",
@@ -503,7 +522,7 @@ export function useExportRunner(input: ExportRunnerInput) {
 				}
 			} catch (error) {
 				if (exportWasCancelled()) return;
-				console.error("Export error:", error);
+				keepError("Export error:", error);
 				const errorMessage = error instanceof Error ? error.message : "Unknown error";
 				if (smokeExportConfig.enabled) {
 					await writeSmokeExportReport(smokeExportConfig.outputPath, {

--- a/src/components/video-editor/export/useSmokeExportAutomation.ts
+++ b/src/components/video-editor/export/useSmokeExportAutomation.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from "react";
 import type { ExportSettings } from "@/lib/exporter";
+import { keepError } from "@/lib/keepConsole";
 import type { getSmokeExportConfig } from "../smokeExportConfig";
 import { writeSmokeExportReport } from "./exportPersistence";
 
@@ -70,7 +71,7 @@ export function useSmokeExportAutomation({
 		if (!config.enabled || startedRef.current) return;
 		if (error) {
 			startedRef.current = true;
-			console.error(`[smoke-export] ${error}`);
+			keepError(`[smoke-export] ${error}`);
 			void writeSmokeExportReport(config.outputPath, {
 				success: false,
 				phase: "load",

--- a/src/lib/exporter/backendPolicy.test.ts
+++ b/src/lib/exporter/backendPolicy.test.ts
@@ -4,6 +4,7 @@ import {
 	getDefaultLightningRenderBackend,
 	normalizeLightningRuntimePlatform,
 	planLightningExportRoutes,
+	resolveLinuxExportRenderBackend,
 	shouldPreferNativeAutoBackend,
 	shouldPreferNativeStaticLayoutBeforeBreeze,
 } from "./backendPolicy";
@@ -192,5 +193,30 @@ describe("backendPolicy", () => {
 				},
 			],
 		});
+	});
+});
+
+describe("resolveLinuxExportRenderBackend (Linux Lightning export backend)", () => {
+	it("honors RECORDLY_LINUX_RENDER_BACKEND=webgl on Linux", () => {
+		expect(resolveLinuxExportRenderBackend("linux", "webgl")).toBe("webgl");
+	});
+
+	it("honors RECORDLY_LINUX_RENDER_BACKEND=webgpu on Linux (experimental WebGPU path)", () => {
+		expect(resolveLinuxExportRenderBackend("linux", "webgpu")).toBe("webgpu");
+	});
+
+	it("defaults the Linux export backend to WebGPU (dynamic webgl fallback lives in the exporter)", () => {
+		expect(resolveLinuxExportRenderBackend("linux", undefined)).toBe("webgpu");
+	});
+
+	it("falls back to the WebGPU default on Linux for invalid or null env values", () => {
+		expect(resolveLinuxExportRenderBackend("linux", "banana")).toBe("webgpu");
+		expect(resolveLinuxExportRenderBackend("linux", null)).toBe("webgpu");
+	});
+
+	it("leaves non-Linux platforms on the default backend selection", () => {
+		expect(resolveLinuxExportRenderBackend("darwin", "webgl")).toBeUndefined();
+		expect(resolveLinuxExportRenderBackend("win32", "webgl")).toBeUndefined();
+		expect(resolveLinuxExportRenderBackend("unknown", "webgpu")).toBeUndefined();
 	});
 });

--- a/src/lib/exporter/backendPolicy.ts
+++ b/src/lib/exporter/backendPolicy.ts
@@ -149,3 +149,29 @@ export function planLightningExportRoutes(options: {
 export function getDefaultLightningRenderBackend(): ExportRenderBackend {
 	return "webgl";
 }
+
+// Linux only: RECORDLY_LINUX_RENDER_BACKEND selects the Lightning export
+// renderer backend on Linux. WebGPU is the default (the original design);
+// when the WebGPU renderer fails mid-export (e.g. pixi's BindGroupSystem
+// "Cannot read properties of undefined (reading '_resourceType')"), the
+// exporter retries the whole pipeline once with WebGL (see
+// modernVideoExporter's webgl fallback retry).
+// - "webgl" | "webgpu" → explicit override, always respected (an explicit
+//   "webgpu" also disables the automatic webgl fallback retry).
+// - unset/invalid → webgpu (default).
+// Non-Linux platforms always return undefined so their behavior stays
+// unchanged.
+export function resolveLinuxExportRenderBackend(
+	platform: LightningRuntimePlatform,
+	envBackend: string | null | undefined,
+): ExportRenderBackend | undefined {
+	if (platform !== "linux") {
+		return undefined;
+	}
+
+	if (envBackend === "webgl" || envBackend === "webgpu") {
+		return envBackend;
+	}
+
+	return "webgpu";
+}

--- a/src/lib/exporter/modernFrameRenderer.test.ts
+++ b/src/lib/exporter/modernFrameRenderer.test.ts
@@ -867,3 +867,23 @@ describe("ModernFrameRenderer temporal webcam sync", () => {
 		).toBeGreaterThan(1);
 	});
 });
+
+describe("ModernFrameRenderer sprite texture replacement", () => {
+	it("destroys the replaced texture immediately on replacement", () => {
+		const renderer = createRenderer() as unknown as {
+			replaceSpriteTexture: (
+				sprite: { texture: { destroy: ReturnType<typeof vi.fn> } },
+				source: CanvasImageSource,
+			) => unknown;
+		};
+		const firstTexture = { destroy: vi.fn() };
+		const sprite = { texture: firstTexture };
+
+		renderer.replaceSpriteTexture(sprite, {} as CanvasImageSource);
+
+		expect(sprite.texture).not.toBe(firstTexture);
+		expect(firstTexture.destroy).toHaveBeenCalledTimes(1);
+		expect(firstTexture.destroy).toHaveBeenCalledWith(true);
+		expect(sprite.texture.destroy).not.toHaveBeenCalled();
+	});
+});

--- a/src/lib/exporter/modernVideoExporter.linuxWebgpuFallback.test.ts
+++ b/src/lib/exporter/modernVideoExporter.linuxWebgpuFallback.test.ts
@@ -1,0 +1,239 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModernVideoExporter as ModernVideoExporterClass } from "./modernVideoExporter";
+
+const WEBGPU_CRASH = new Error("Cannot read properties of undefined (reading '_resourceType')");
+
+const mocks = vi.hoisted(() => {
+	const videoInfo = {
+		width: 1920,
+		height: 1080,
+		duration: 1,
+		streamDuration: 1,
+		frameRate: 30,
+		codec: "h264",
+		hasAudio: false,
+		audioCodec: null,
+		audioSampleRate: null,
+	};
+
+	return {
+		videoInfo,
+		frameRendererDestroy: vi.fn(),
+		frameRendererGetBackend: vi.fn(() => "webgl"),
+		frameRendererInitialize: vi.fn(async () => {}),
+		frameRendererRenderFrame: vi.fn(async () => {}),
+		streamingDecoderDestroy: vi.fn(),
+		streamingDecoderCancel: vi.fn(),
+		streamingDecoderDecodeAll: vi.fn(async () => {}),
+		streamingDecoderGetDemuxer: vi.fn(() => null),
+		streamingDecoderGetEffectiveDuration: vi.fn(() => 1),
+		streamingDecoderLoadMetadata: vi.fn(async () => videoInfo),
+		muxerDestroy: vi.fn(),
+		muxerFinalize: vi.fn(async () => ({
+			mode: "buffer" as const,
+			blob: new Blob([], { type: "video/mp4" }),
+		})),
+		muxerInitialize: vi.fn(async () => {}),
+	};
+});
+
+vi.mock("./streamingDecoder", () => ({
+	StreamingVideoDecoder: vi.fn().mockImplementation(function () {
+		return {
+			cancel: mocks.streamingDecoderCancel,
+			decodeAll: mocks.streamingDecoderDecodeAll,
+			destroy: mocks.streamingDecoderDestroy,
+			getDemuxer: mocks.streamingDecoderGetDemuxer,
+			getEffectiveDuration: mocks.streamingDecoderGetEffectiveDuration,
+			loadMetadata: mocks.streamingDecoderLoadMetadata,
+		};
+	}),
+}));
+
+vi.mock("./modernFrameRenderer", () => ({
+	FrameRenderer: vi.fn().mockImplementation(function () {
+		return {
+			destroy: mocks.frameRendererDestroy,
+			getRendererBackend: mocks.frameRendererGetBackend,
+			initialize: mocks.frameRendererInitialize,
+			renderFrame: mocks.frameRendererRenderFrame,
+		};
+	}),
+}));
+
+vi.mock("./muxer", () => ({
+	VideoMuxer: vi.fn().mockImplementation(function () {
+		return {
+			destroy: mocks.muxerDestroy,
+			finalize: mocks.muxerFinalize,
+			initialize: mocks.muxerInitialize,
+		};
+	}),
+}));
+
+type ExportResultShape = {
+	success: boolean;
+	blob?: Blob;
+	error?: string;
+	metrics?: { renderBackend?: string; renderFallbackUsed?: boolean };
+};
+
+function stubLinuxNavigator() {
+	vi.stubGlobal("navigator", { platform: "Linux x86_64" });
+}
+
+function stubLinuxWindow(envBackend?: string) {
+	vi.stubGlobal("window", {
+		electronAPI:
+			envBackend === undefined
+				? {}
+				: { getLinuxRenderBackendEnv: vi.fn(async () => envBackend) },
+	});
+}
+
+// The decode loop hands each frame to the exporter callback; making the
+// callback run reproduces the real crash site (renderer.renderFrame inside
+// decodeAll), not an error fabricated at an arbitrary stage.
+function decodeAllInvokesCallbackOnce() {
+	mocks.streamingDecoderDecodeAll.mockImplementationOnce(
+		async (_frameRate, _trimRegions, _speedRegions, callback) => {
+			await callback({} as never, 0, 0, 0);
+		},
+	);
+}
+
+describe("ModernVideoExporter Linux webgpu → webgl fallback", () => {
+	let ModernVideoExporter: typeof ModernVideoExporterClass;
+	let FrameRenderer: (...args: unknown[]) => unknown;
+	let consoleSpies: Array<ReturnType<typeof vi.spyOn>> = [];
+
+	beforeAll(async () => {
+		({ ModernVideoExporter } = await import("./modernVideoExporter"));
+		({ FrameRenderer } = await import("./modernFrameRenderer"));
+	}, 30_000);
+
+	const createLinuxExporter = () =>
+		new ModernVideoExporter({
+			videoUrl: "file:///recording.mp4",
+			width: 1920,
+			height: 1080,
+			frameRate: 30,
+			bitrate: 8_000_000,
+			wallpaper: "#101010",
+			padding: 0,
+			borderRadius: 0,
+			backgroundBlur: 0,
+			shadowIntensity: 0,
+			showShadow: false,
+			cropRegion: { x: 0, y: 0, width: 1, height: 1 },
+			backendPreference: "webcodecs",
+		} as never) as unknown as {
+			export: () => Promise<ExportResultShape>;
+			initializeEncoder: () => Promise<unknown>;
+		};
+
+	// restoreAllMocks would wipe the vi.mock factory implementations, so the
+	// console spies are restored individually instead.
+	beforeEach(() => {
+		consoleSpies = [
+			vi.spyOn(console, "error").mockImplementation(() => {}),
+			vi.spyOn(console, "warn").mockImplementation(() => {}),
+			vi.spyOn(console, "log").mockImplementation(() => {}),
+		];
+	});
+
+	afterEach(() => {
+		for (const spy of consoleSpies) {
+			spy.mockRestore();
+		}
+		vi.clearAllMocks();
+		vi.unstubAllGlobals();
+	});
+
+	it("retries the export once from scratch with webgl when the webgpu renderer crashes mid-export", async () => {
+		stubLinuxNavigator();
+		stubLinuxWindow();
+
+		const exporter = createLinuxExporter();
+		vi.spyOn(exporter, "initializeEncoder").mockResolvedValue({
+			codec: "avc1.640034",
+			hardwareAcceleration: "prefer-hardware",
+		});
+
+		// Attempt 1: webgpu initializes, then the first render crashes.
+		mocks.frameRendererGetBackend.mockReturnValueOnce("webgpu").mockReturnValueOnce("webgl");
+		mocks.frameRendererRenderFrame.mockRejectedValueOnce(WEBGPU_CRASH);
+		decodeAllInvokesCallbackOnce();
+
+		const result = await exporter.export();
+
+		expect(result.success).toBe(true);
+		expect(result.blob).toBeInstanceOf(Blob);
+		expect(FrameRenderer).toHaveBeenCalledTimes(2);
+		expect(FrameRenderer).toHaveBeenCalledWith(
+			expect.objectContaining({ preferredRenderBackend: "webgpu" }),
+		);
+		expect(FrameRenderer).toHaveBeenCalledWith(
+			expect.objectContaining({ preferredRenderBackend: "webgl" }),
+		);
+		expect(mocks.streamingDecoderLoadMetadata).toHaveBeenCalledTimes(2);
+		expect(mocks.muxerFinalize).toHaveBeenCalledTimes(1);
+		expect(result.metrics?.renderBackend).toBe("webgl");
+		expect(result.metrics?.renderFallbackUsed).toBe(true);
+		expect(console.error).toHaveBeenCalledWith(
+			expect.stringContaining("retrying with webgl fallback"),
+			expect.any(Error),
+		);
+	}, 15_000);
+
+	it("does not retry and propagates the error when RECORDLY_LINUX_RENDER_BACKEND=webgpu forced the backend", async () => {
+		stubLinuxNavigator();
+		stubLinuxWindow("webgpu");
+
+		const exporter = createLinuxExporter();
+		vi.spyOn(exporter, "initializeEncoder").mockResolvedValue({
+			codec: "avc1.640034",
+			hardwareAcceleration: "prefer-hardware",
+		});
+
+		mocks.frameRendererGetBackend.mockReturnValue("webgpu");
+		mocks.frameRendererRenderFrame.mockRejectedValueOnce(WEBGPU_CRASH);
+		decodeAllInvokesCallbackOnce();
+
+		const result = await exporter.export();
+
+		expect(result.success).toBe(false);
+		expect(result.error).toContain("_resourceType");
+		expect(FrameRenderer).toHaveBeenCalledTimes(1);
+		expect(mocks.streamingDecoderLoadMetadata).toHaveBeenCalledTimes(1);
+		expect(console.error).not.toHaveBeenCalledWith(
+			expect.stringContaining("retrying with webgl fallback"),
+			expect.any(Error),
+		);
+	}, 15_000);
+
+	it("retries at most once when the webgl fallback attempt also fails", async () => {
+		stubLinuxNavigator();
+		stubLinuxWindow();
+
+		const exporter = createLinuxExporter();
+		vi.spyOn(exporter, "initializeEncoder").mockResolvedValue({
+			codec: "avc1.640034",
+			hardwareAcceleration: "prefer-hardware",
+		});
+
+		mocks.frameRendererGetBackend.mockReturnValueOnce("webgpu").mockReturnValueOnce("webgl");
+		mocks.frameRendererRenderFrame.mockRejectedValue(WEBGPU_CRASH);
+		mocks.streamingDecoderDecodeAll.mockImplementation(
+			async (_frameRate, _trimRegions, _speedRegions, callback) => {
+				await callback({} as never, 0, 0, 0);
+			},
+		);
+
+		const result = await exporter.export();
+
+		expect(result.success).toBe(false);
+		expect(FrameRenderer).toHaveBeenCalledTimes(2);
+		expect(mocks.streamingDecoderLoadMetadata).toHaveBeenCalledTimes(2);
+	}, 15_000);
+});

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -45,6 +45,7 @@ import {
 	getWebcamOverlaySizePx,
 	isWebcamCropRegionDefault,
 } from "@/components/video-editor/webcamOverlay";
+import { keepError, keepLog } from "@/lib/keepConsole";
 import { getEffectiveVideoStreamDurationSeconds } from "@/lib/mediaTiming";
 import {
 	DEFAULT_WALLPAPER_PATH,
@@ -54,6 +55,7 @@ import {
 import { AudioProcessor, isAacAudioEncodingSupported } from "./audioEncoder";
 import {
 	normalizeLightningRuntimePlatform,
+	resolveLinuxExportRenderBackend,
 	shouldPreferNativeAutoBackend,
 	shouldPreferNativeStaticLayoutBeforeBreeze,
 } from "./backendPolicy";
@@ -325,6 +327,10 @@ export class ModernVideoExporter {
 	private exportStartTimeMs = 0;
 	private lastThroughputLogTimeMs = 0;
 	private renderBackend: ExportRenderBackend | null = null;
+	private renderStageFailure = false;
+	private renderFallbackUsed = false;
+	private linuxWebglFallbackOverride = false;
+	private linuxWebgpuEnvForced = false;
 	private encodeBackend: ExportEncodeBackend | null = null;
 	private encoderName: string | null = null;
 	private backpressureProfile: ExportBackpressureProfile | null = null;
@@ -375,13 +381,20 @@ export class ModernVideoExporter {
 	async export(): Promise<ExportResult> {
 		let useFallbackMediaSource = false;
 		let retriedWithFallbackMediaSource = false;
+		let retriedWithWebglRenderFallback = false;
+		this.renderFallbackUsed = false;
+		this.linuxWebglFallbackOverride = false;
+		this.linuxWebgpuEnvForced = false;
 
 		while (true) {
 			let shouldRetryWithFallbackMediaSource = false;
+			let shouldRetryWithWebglRenderFallback = false;
 			try {
 				this.cleanup();
 				this.cancelled = false;
 				this.encoderError = null;
+				this.renderBackend = null;
+				this.renderStageFailure = false;
 				this.nativeEncoderError = null;
 				this.nativeStaticLayoutSkipReason = null;
 				this.nativeStaticLayoutSkipReasons = [];
@@ -588,7 +601,7 @@ export class ModernVideoExporter {
 				this.renderer = new ModernFrameRenderer({
 					width: this.config.width,
 					height: this.config.height,
-					preferredRenderBackend: undefined,
+					preferredRenderBackend: await this.resolvePreferredRenderBackend(),
 					wallpaper: this.config.wallpaper,
 					zoomRegions: this.config.zoomRegions,
 					showShadow: this.config.showShadow,
@@ -644,10 +657,15 @@ export class ModernVideoExporter {
 					zoomSmoothness: this.config.zoomSmoothness,
 					zoomClassicMode: this.config.zoomClassicMode,
 				});
-				await this.renderer.initialize();
+				try {
+					await this.renderer.initialize();
+				} catch (error) {
+					this.renderStageFailure = true;
+					throw error;
+				}
 				this.rendererInitTimeMs = this.getNowMs() - stageStartedAt;
 				this.renderBackend = this.renderer.getRendererBackend();
-				console.log(`[VideoExporter] Using ${this.renderBackend} render backend`);
+				keepLog(`[VideoExporter] Using ${this.renderBackend} render backend`);
 
 				if (!useNativeEncoder) {
 					const hasAudio = nativeAudioPlan.audioMode !== "none";
@@ -693,13 +711,18 @@ export class ModernVideoExporter {
 						const sourceTimestampUs = sourceTimestampMs * 1000;
 						const cursorTimestampUs = cursorTimestampMs * 1000;
 						const renderStartedAt = this.getNowMs();
-						await this.renderer!.renderFrame(
-							videoFrame,
-							sourceTimestampUs,
-							cursorTimestampUs,
-							frameDuration,
-							timestamp,
-						);
+						try {
+							await this.renderer!.renderFrame(
+								videoFrame,
+								sourceTimestampUs,
+								cursorTimestampUs,
+								frameDuration,
+								timestamp,
+							);
+						} catch (error) {
+							this.renderStageFailure = true;
+							throw error;
+						}
 						this.renderFrameTimeMs += this.getNowMs() - renderStartedAt;
 
 						if (this.cancelled) {
@@ -888,7 +911,23 @@ export class ModernVideoExporter {
 					metrics: this.buildExportMetrics(),
 				};
 			} catch (error) {
+				const attemptRenderBackend =
+					this.renderBackend ?? this.renderer?.getRendererBackend() ?? null;
 				if (
+					!retriedWithWebglRenderFallback &&
+					this.shouldRetryWithWebglRenderFallback(attemptRenderBackend)
+				) {
+					retriedWithWebglRenderFallback = true;
+					shouldRetryWithWebglRenderFallback = true;
+					this.renderFallbackUsed = true;
+					this.linuxWebglFallbackOverride = true;
+					keepError(
+						`[VideoExporter] WebGPU export failed (${
+							error instanceof Error ? error.message : String(error)
+						}); retrying with webgl fallback`,
+						error,
+					);
+				} else if (
 					!useFallbackMediaSource &&
 					!retriedWithFallbackMediaSource &&
 					this.shouldRetryWithFallbackMediaSource(error)
@@ -918,7 +957,11 @@ export class ModernVideoExporter {
 					};
 				}
 			} finally {
-				if (!shouldRetryWithFallbackMediaSource && this.totalExportStartTimeMs > 0) {
+				if (
+					!shouldRetryWithFallbackMediaSource &&
+					!shouldRetryWithWebglRenderFallback &&
+					this.totalExportStartTimeMs > 0
+				) {
 					console.log(
 						`[VideoExporter] Final metrics ${JSON.stringify(this.buildExportMetrics())}`,
 					);
@@ -926,10 +969,37 @@ export class ModernVideoExporter {
 				this.cleanup();
 			}
 
-			if (shouldRetryWithFallbackMediaSource) {
+			if (shouldRetryWithFallbackMediaSource || shouldRetryWithWebglRenderFallback) {
 				continue;
 			}
 		}
+	}
+
+	// Linux only: when the default WebGPU export renderer fails mid-export
+	// (renderer init or render crash, e.g. pixi's BindGroupSystem
+	// "Cannot read properties of undefined (reading '_resourceType')"), retry
+	// the whole export pipeline once with WebGL. An explicit
+	// RECORDLY_LINUX_RENDER_BACKEND=webgpu disables the retry — the operator
+	// chose webgpu on purpose, so the failure must surface, not be retried.
+	// Non-Linux platforms, non-webgpu attempts, and non-renderer failures
+	// never take this path.
+	//
+	// Known limitation (conscious decision): if WebGPU fails during init
+	// BEFORE the frame renderer reports its backend (rendererBackend is only
+	// set after createPixiApplication succeeds — FrameRenderer.ts:521), the
+	// attempt backend is unidentifiable and no webgl retry happens. The
+	// FrameRenderer's own init fallback order (webgpu → webgl) already covers
+	// init-stage failures, so this edge has not been observed in practice.
+	private shouldRetryWithWebglRenderFallback(
+		attemptRenderBackend: ExportRenderBackend | null,
+	): boolean {
+		return (
+			this.getRuntimePlatform() === "linux" &&
+			attemptRenderBackend === "webgpu" &&
+			!this.linuxWebgpuEnvForced &&
+			this.renderStageFailure &&
+			!this.cancelled
+		);
 	}
 
 	private shouldRetryWithFallbackMediaSource(error: unknown): boolean {
@@ -963,6 +1033,39 @@ export class ModernVideoExporter {
 		}
 
 		return normalizeLightningRuntimePlatform(navigator.platform || navigator.userAgent || "");
+	}
+
+	// Linux only: RECORDLY_LINUX_RENDER_BACKEND selects the export render
+	// backend ("webgl" | "webgpu" respected; unset/invalid → webgpu, the
+	// default). After a WebGPU mid-export failure, the webgl fallback retry
+	// forces webgl for the restarted pipeline. Non-Linux platforms keep the
+	// default backend selection.
+	private async resolvePreferredRenderBackend(): Promise<ExportRenderBackend | undefined> {
+		if (this.getRuntimePlatform() !== "linux") {
+			return undefined;
+		}
+
+		if (this.linuxWebglFallbackOverride) {
+			keepLog("[VideoExporter] Linux export render backend: webgl (webgpu fallback retry)");
+			return "webgl";
+		}
+
+		let envBackend: string | null | undefined;
+		try {
+			envBackend = await window.electronAPI?.getLinuxRenderBackendEnv?.();
+		} catch (error) {
+			keepError(
+				"[VideoExporter] Failed to read RECORDLY_LINUX_RENDER_BACKEND; defaulting to webgpu:",
+				error,
+			);
+		}
+
+		const backend = resolveLinuxExportRenderBackend("linux", envBackend);
+		this.linuxWebgpuEnvForced = envBackend === "webgpu";
+		keepLog(
+			`[VideoExporter] Linux export render backend: ${backend} (${envBackend ? `RECORDLY_LINUX_RENDER_BACKEND=${envBackend}` : "default"})`,
+		);
+		return backend;
 	}
 
 	private getLightningErrorGuidance(message: string): string[] {
@@ -3225,6 +3328,7 @@ export class ModernVideoExporter {
 			finalizationMs: this.finalizationTimeMs,
 			frameCount: this.processedFrameCount,
 			renderBackend: this.renderBackend ?? undefined,
+			renderFallbackUsed: this.renderFallbackUsed || undefined,
 			encodeBackend: this.encodeBackend ?? undefined,
 			encoderName: this.encoderName ?? undefined,
 			backpressureProfile: this.backpressureProfile?.name,

--- a/src/lib/exporter/types.ts
+++ b/src/lib/exporter/types.ts
@@ -130,6 +130,9 @@ export interface ExportMetrics {
 	finalizationMs?: number;
 	frameCount?: number;
 	renderBackend?: ExportRenderBackend;
+	/** True when the export completed on the webgl fallback retry after a
+	 * WebGPU renderer failure (Linux only; absent otherwise). */
+	renderFallbackUsed?: boolean;
 	encodeBackend?: ExportEncodeBackend;
 	encoderName?: string;
 	backpressureProfile?: string;

--- a/src/lib/keepConsole.test.ts
+++ b/src/lib/keepConsole.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { keepError, keepLog } from "./keepConsole";
+
+describe("keepConsole", () => {
+	beforeEach(() => {
+		vi.spyOn(console, "log").mockImplementation(() => undefined);
+		vi.spyOn(console, "error").mockImplementation(() => undefined);
+	});
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it("keepLog forwards every argument to console.log untouched", () => {
+		keepLog("[smoke-export] Export run started", {
+			format: "mp4",
+			quality: "good",
+		});
+		expect(vi.mocked(console.log).mock.calls).toEqual([
+			["[smoke-export] Export run started", { format: "mp4", quality: "good" }],
+		]);
+	});
+
+	it("keepError forwards every argument to console.error untouched", () => {
+		keepError("[smoke-export] Export failed", new Error("boom"));
+		expect(vi.mocked(console.error).mock.calls).toEqual([
+			["[smoke-export] Export failed", new Error("boom")],
+		]);
+	});
+
+	it("calls are not syntactic console.* invocations so terser drop_console keeps them", () => {
+		// Regression intent: the wrapper must dispatch through an aliased sink.
+		// If someone "simplifies" it back to `console.log(...)`, the production
+		// bundle goes silent again (vite terser drop_console) and only the
+		// post-build marker check catches it. Keep the alias.
+		const source = keepLog.toString();
+		expect(source).not.toMatch(/console\.(log|error)\s*\(/);
+	});
+});

--- a/src/lib/keepConsole.ts
+++ b/src/lib/keepConsole.ts
@@ -1,0 +1,18 @@
+// Smoke-export diagnostics must stay visible in packaged builds. The renderer
+// production bundle is minified with terser `drop_console: true`
+// (vite.config.ts), which strips EVERY syntactic `console.*` call — including
+// console.error. Dispatching through an aliased sink is not a syntactic
+// console call, so terser keeps it and `--enable-logging=stderr` can surface
+// the logs when validating a build.
+//
+// Use these wrappers only for diagnostics that must survive production builds
+// (smoke export path, backend selection); regular code keeps plain console.
+const consoleSink = console;
+
+export function keepLog(...args: unknown[]): void {
+	consoleSink.log(...args);
+}
+
+export function keepError(...args: unknown[]): void {
+	consoleSink.error(...args);
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
 		include: [
 			"src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
 			"electron/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+			"scripts/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts}",
 		],
 	},
 	resolve: {


### PR DESCRIPTION
## Problem

Lightning (Beta) MP4 export fails on Linux with:

```
Lightning (Beta) export failed.
Reason: Cannot read properties of undefined (reading '_resourceType')
Renderer: webgpu
Encoder path: WebCodecs (avc1.640033/prefer-software/realtime)
```

Reproduced on the official v1.4.0-beta.1 AppImage (Arch Linux, Hyprland/Wayland, Electron 43.1.0, AMD RADV). The string `_resourceType` only exists in pixi.js's WebGPU renderer (`gpu/BindGroupSystem`): the crash happens inside the WebGPU render stage, before any frame is encoded (`frameCount: 0`). The WebCodecs software encoder path works — confirmed with a minimal repro (clean Electron + pixi WebGPURenderer + per-frame texture swap) where canvas/WebGL pipelines encode successfully.

## Solution

- **WebGPU remains the default** render backend on Linux (design unchanged).
- On Linux, when a **render-stage failure** occurs with WebGPU, the export **retries once from scratch** with the WebGL renderer (state fully cleaned between attempts, max 1 retry). `renderFallbackUsed` is reported in export metrics/report.
- `RECORDLY_LINUX_RENDER_BACKEND=webgl|webgpu` env override for debugging/validation; a forced value disables the automatic fallback.
- Smoke-export diagnostics now survive packaged builds (terser `drop_console`) via `keepLog`/`keepError` wrappers, and `scripts/verify-smoke-build.mjs` guards against stale packaging.

## Testing

- New unit tests: backend policy defaults/overrides (unset→webgpu, forced values honored, non-linux→undefined) and fallback behavior (crash→retry→success with `renderBackend: webgl` + `renderFallbackUsed: true`; forced env→no retry; max 1 retry). Full suite: **1103 tests passing**, biome and tsc clean.
- End-to-end on Linux (Hyprland/Wayland), via the built-in smoke export: WebGPU attempt fails with the known pixi crash → automatic WebGL retry → `success: true`, 327 frames, valid playable MP4 (1080p30). Forcing webgl exports directly with no WebGPU attempt.
- **macOS/Windows unchanged**: the policy returns `undefined` outside Linux, the fallback is gated to the linux runtime platform, and the new IPC (`get-linux-render-backend-env`) is additive and returns `null` elsewhere.

## Notes

- Relates to #901 (alternative take on Linux WebGPU export failures) — happy to coordinate.
- The underlying pixi.js WebGPU crash (`BindGroupSystem._resourceType` on first render) is an upstream issue; this PR makes the app resilient to it while it gets fixed upstream.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Linux video exports now default to WebGPU and can use WebGL when explicitly configured.
  - If WebGPU fails during export, the app automatically retries once with WebGL when available.
  - Export metrics indicate when a fallback was used.
  - Export and smoke-run diagnostics remain visible in production builds.

- **Bug Fixes**
  - Improved resilience for Linux exports affected by mid-export rendering failures.

- **Tests**
  - Added coverage for backend selection, fallback behavior, texture replacement, diagnostics, and packaged-build verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->