### PR TITLE
fix(macos): keep mic audio when system audio is enabled

### DIFF
--- a/electron/ipc/recording/diagnostics.test.ts
+++ b/electron/ipc/recording/diagnostics.test.ts
@@ -134,6 +134,42 @@ describe("getCompanionAudioFallbackPaths", () => {
 		]);
 	});
 
+	it("returns both mac sidecars instead of the video when a system sidecar exists", async () => {
+		const videoPath = path.join(tempRoot, "recording.mp4");
+		const systemPath = path.join(tempRoot, "recording.system.m4a");
+		const micPath = path.join(tempRoot, "recording.mic.m4a");
+
+		await Promise.all([
+			fs.writeFile(videoPath, "video"),
+			fs.writeFile(systemPath, "system"),
+			fs.writeFile(micPath, "mic"),
+		]);
+
+		execFileMock.mockImplementation(
+			(
+				_file: string,
+				_args: string[],
+				_options: Record<string, unknown>,
+				callback: ExecFileCallback,
+			) => {
+				const error = new Error("ffmpeg probe found embedded audio") as Error & {
+					stderr?: string;
+				};
+				error.stderr = "Stream #0:1: Audio: aac";
+				callback(error, "", error.stderr);
+			},
+		);
+
+		const { getCompanionAudioFallbackPaths } = await import("./diagnostics");
+
+		// The inline mp4 track holds system audio only, so returning [videoPath]
+		// here silently dropped the microphone.
+		await expect(getCompanionAudioFallbackPaths(videoPath)).resolves.toEqual([
+			systemPath,
+			micPath,
+		]);
+	});
+
 	it("prefers the mac mic companion alone when embedded audio already exists and no system sidecar is present", async () => {
 		const videoPath = path.join(tempRoot, "recording.mp4");
 		const micPath = path.join(tempRoot, "recording.mic.m4a");

--- a/electron/ipc/recording/diagnostics.ts
+++ b/electron/ipc/recording/diagnostics.ts
@@ -524,7 +524,17 @@ export async function getCompanionAudioFallbackInfo(videoPath: string) {
 		if (!hasUsableMacSystemCompanion && usableMacMicOnlyCompanions.length > 0) {
 			paths = usableMacMicOnlyCompanions;
 		} else if (hasUsableMacSystemCompanion) {
-			paths = [videoPath];
+			// The inline mp4 audio track carries system audio only (the helper skips
+			// the microphone while system audio is captured), so returning the video
+			// alone drops the mic entirely.  Hand over both mac sidecars instead and
+			// let the renderer route them as independent system/mic tracks.
+			paths = Array.from(
+				new Set(
+					companionCandidates.flatMap((candidate) =>
+						candidate.platform === "mac" ? candidate.usablePaths : [],
+					),
+				),
+			);
 		} else {
 			const companionPaths = Array.from(
 				new Set(

--- a/electron/ipc/recording/diagnostics.ts
+++ b/electron/ipc/recording/diagnostics.ts
@@ -496,6 +496,16 @@ export async function getCompanionAudioFallbackPaths(videoPath: string) {
 	return paths;
 }
 
+/**
+ * Resolve which audio files the editor should play alongside `videoPath`, and
+ * the start delay recorded for each.
+ *
+ * The renderer treats a `.system.`/`.mic.` pair as independent tracks and mutes
+ * the video's own track when both are present.  The macOS helper writes system
+ * audio to the inline track but keeps both sources as sidecars, so once a mac
+ * system sidecar exists the sidecars are authoritative and are returned in place
+ * of the video.  Other layouts keep the embedded track and add the mic sidecar.
+ */
 export async function getCompanionAudioFallbackInfo(videoPath: string) {
 	const companionCandidates = await getUsableCompanionAudioCandidates(videoPath);
 	if (companionCandidates.length === 0) {


### PR DESCRIPTION
## Description

`getCompanionAudioFallbackInfo` returned only the video path when a macOS system sidecar existed, assuming the inline mp4 track was a complete mix. The capture helper writes system audio alone to that track, so the microphone was dropped from preview and export whenever both sources were enabled — the recorded narration was silent even though it had been captured correctly to `recording-<ts>.mic.m4a`.

Return both macOS sidecars instead, so the renderer routes them as separate system and mic tracks and mutes the silent embedded track. Existing recordings recover their audio on reopen.

## Motivation

Recording with **both System audio and Microphone enabled** produces a video with no audible narration on macOS. That's the ordinary configuration for a narrated screen recording, so the failure hits a common path — and it's silent in both senses: nothing warns the user, and the loss is only discovered on playback.

Measured on affected recordings:

```
recording-<ts>.mp4          max_volume: -91.0 dB   # embedded track, digital silence
recording-<ts>.mic.m4a      max_volume: -20.3 dB   # speech, captured correctly
recording-<ts>.system.m4a   max_volume: -91.0 dB   # nothing was playing
```

Capture works; routing of the captured audio does not.

**Root cause.** `audioRoutingEngine` is built around two sidecars — it derives a track id from the filename, plays `.system.` and `.mic.` with independent gains, and mutes the embedded track when dedicated sidecars exist. `getCompanionAudioFallbackInfo` never handed it those sidecars:

```ts
} else if (hasUsableMacSystemCompanion) {
    paths = [videoPath];
}
```

Downstream this collapses to `externalAudioPaths: []` → `pathsByTrack: {}` → `includeEmbeddedInExport: true`, so preview and export use only the embedded track and `.mic.m4a` is never opened.

The branch assumed that embedded track was a complete system+mic mix. It isn't: `ScreenCaptureKitRecorder.swift` appends the mic to the inline track only when system audio is off (`if !capturesSystemAudio`), so with system audio enabled it carries system audio alone — silence when nothing is playing.

"Usable" is decided purely by `stat.size > 0`, so a 4 KB *silent* `.system.m4a` is enough to trigger the bad branch.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)

Fixes #912

## Screenshots / Video

Not applicable in the usual sense — this is an audio-only defect with no visual change, and a screenshot of a silent waveform proves little. The measurements above are the evidence; they're reproducible with the commands in the testing guide below.

## Testing Guide

**Reproduce (on `main`):**

1. Run the app on macOS: `npm run dev`
2. Enable **both** System audio and Microphone.
3. Keep the speakers silent — play no music or video. This matters: the silent `.system.m4a` is what triggers the bad branch, and with audio playing you'd hear the system track and might not notice the mic is gone.
4. Record ~10s while speaking, then stop and play back in the editor. It is silent.

**Verify the captured files:**

```bash
cd ~/Library/Application\ Support/Recordly/recordings
for f in *.mp4 *.mic.m4a; do printf "%-40s " "$f"; ffmpeg -i "$f" -map 0:a:0 -af volumedetect -f null - 2>&1 | grep max_volume; done
```

The newest `.mic.m4a` sits near -20 dB while the `.mp4` sits at -91 dB — the mic captured, the video silent.

**Confirm the fix:** check out this branch and reopen that same recording. The narration is audible without re-recording, since the change affects which files the editor loads rather than how anything is captured.

**Automated:**

```bash
npx vitest --run          # 1084 tests / 120 files pass
npx tsc --noEmit          # clean
npx biome lint .          # clean
```

The added regression test was verified non-vacuous: without the fix it fails, returning `[videoPath]` instead of the two sidecars.

## Scope

This fixes preview and export. The raw `.mp4` in the recordings folder remains system-audio-only, because the helper still skips the mic on the inline track. Making that file self-contained requires real PCM mixing in the capture path — tracked as the secondary defect in #912 and deliberately kept out of this change.

The fix is guarded to `platform === "mac"`, so the Windows `.wav` layout is untouched.

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have added any necessary screenshots or videos. *(audio-only defect — `volumedetect` measurements included in place of a screenshot)*
- [x] I have linked related issue(s) and updated the changelog if applicable. *(linked #912; the repo has no changelog file)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added regression coverage for macOS recordings with embedded system audio and a separate microphone track.
  - Verified that both system-audio and microphone sidecar paths are retained during audio processing, preventing microphone audio from being omitted.

- **Documentation**
  - Clarified audio-track selection when recordings include embedded audio alongside separate system-audio or microphone tracks.
  - Documented when sidecar tracks take precedence over embedded audio during processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->