### PR TITLE
fix(macOS): preserve companion routing and preview timing

### DIFF
--- a/electron/ipc/recording/diagnostics.test.ts
+++ b/electron/ipc/recording/diagnostics.test.ts
@@ -160,6 +160,58 @@ describe("getCompanionAudioFallbackPaths", () => {
 		await expect(getCompanionAudioFallbackPaths(videoPath)).resolves.toEqual([micPath]);
 	});
 
+	it.each([
+		{ name: "both mac tracks", embedded: true, suffixes: [".system.m4a", ".mic.m4a"] },
+		{ name: "mac mic only", embedded: true, suffixes: [".mic.m4a"] },
+		{ name: "mac system only", embedded: true, suffixes: [".system.m4a"] },
+		{ name: "no embedded audio", embedded: false, suffixes: [".system.m4a", ".mic.m4a"] },
+		{ name: "no companions", embedded: true, suffixes: [] },
+		{ name: "legacy mac webm tracks", embedded: true, suffixes: [".system.webm", ".mic.webm"] },
+		{
+			name: "native system and browser mic",
+			embedded: true,
+			suffixes: [".system.m4a", ".mic.webm"],
+		},
+	])("uses independent tracks and their timing for $name", async ({ embedded, suffixes }) => {
+		const videoPath = path.join(tempRoot, "recording.mp4");
+		const paths = suffixes.map((suffix) => path.join(tempRoot, `recording${suffix}`));
+		await fs.writeFile(videoPath, "video");
+		await Promise.all(
+			paths.map(async (audioPath) => {
+				await fs.writeFile(audioPath, "audio");
+				await fs.writeFile(`${audioPath}.json`, JSON.stringify({ startDelayMs: 125 }));
+			}),
+		);
+		execFileMock.mockImplementation(
+			(
+				_file: string,
+				_args: string[],
+				_options: Record<string, unknown>,
+				callback: ExecFileCallback,
+			) => {
+				const stderr = embedded ? "Stream #0:1: Audio: aac" : "Stream #0:0: Video: h264";
+				callback(Object.assign(new Error("probe"), { stderr }), "", stderr);
+			},
+		);
+
+		const { getCompanionAudioFallbackInfo } = await import("./diagnostics");
+		await expect(getCompanionAudioFallbackInfo(videoPath)).resolves.toEqual({
+			paths,
+			startDelayMsByPath: Object.fromEntries(paths.map((audioPath) => [audioPath, 125])),
+		});
+	});
+
+	it("ignores empty mac sidecars and preserves embedded-only playback", async () => {
+		const videoPath = path.join(tempRoot, "recording.mp4");
+		await fs.writeFile(videoPath, "video");
+		await fs.writeFile(path.join(tempRoot, "recording.system.m4a"), "");
+		const { getCompanionAudioFallbackInfo } = await import("./diagnostics");
+		await expect(getCompanionAudioFallbackInfo(videoPath)).resolves.toEqual({
+			paths: [],
+			startDelayMsByPath: {},
+		});
+	});
+
 	it("loads saved sidecar timing metadata alongside companion audio paths", async () => {
 		const videoPath = path.join(tempRoot, "recording.mp4");
 		const micPath = path.join(tempRoot, "recording.mic.webm");

--- a/electron/ipc/recording/diagnostics.ts
+++ b/electron/ipc/recording/diagnostics.ts
@@ -524,7 +524,10 @@ export async function getCompanionAudioFallbackInfo(videoPath: string) {
 		if (!hasUsableMacSystemCompanion && usableMacMicOnlyCompanions.length > 0) {
 			paths = usableMacMicOnlyCompanions;
 		} else if (hasUsableMacSystemCompanion) {
-			paths = [videoPath];
+			// macOS keeps system and mic separate; an embedded stream is not a full mix.
+			paths = Array.from(
+				new Set(companionCandidates.flatMap((candidate) => candidate.usablePaths)),
+			);
 		} else {
 			const companionPaths = Array.from(
 				new Set(

--- a/src/components/video-editor/audio/useAudioPreviewSync.test.ts
+++ b/src/components/video-editor/audio/useAudioPreviewSync.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAudioPreviewSync } from "./useAudioPreviewSync";
+
+vi.mock("react", () => ({
+	useMemo: (fn: () => unknown) => fn(),
+	useCallback: (fn: unknown) => fn,
+	useRef: (current: unknown) => ({ current }),
+	useEffect: (fn: () => unknown) => {
+		fn();
+	},
+}));
+vi.mock("@/lib/exporter/localMediaSource", () => ({
+	resolveMediaElementSource: async (src: string) => ({ src, revoke: () => {} }),
+}));
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("companion preview timing", () => {
+	it.each([
+		{ suffix: "mic", delay: 1250, expected: 1.75 },
+		{ suffix: "system", delay: 1250, expected: 1.75 },
+		{ suffix: "mic", delay: 0, expected: 3 },
+		{ suffix: "mic", delay: undefined, expected: 3 },
+		{ suffix: "mic", delay: -100, expected: 3 },
+		{ suffix: "mic", delay: 4000, expected: 0 },
+	])("seeks $suffix with recorded delay $delay ms", async ({ suffix, delay, expected }) => {
+		const elements: Array<{ currentTime: number }> = [];
+		vi.stubGlobal(
+			"Audio",
+			class {
+				currentTime = 0;
+				duration = 10;
+				paused = true;
+				dataset = {};
+				load() {}
+				pause() {}
+				constructor() {
+					elements.push(this);
+				}
+			},
+		);
+		const audioPath = `/recording.${suffix}.m4a`;
+		useAudioPreviewSync({
+			audioRegions: [],
+			previewVolume: 1,
+			isPlaying: false,
+			currentTime: 3,
+			timelineTime: 3,
+			duration: 10,
+			effectiveSpeedRegions: [],
+			previewSourceAudioFallbackPaths: [audioPath],
+			sourceAudioFallbackStartDelayMsByPath:
+				delay === undefined ? {} : { [audioPath]: delay },
+			sourceAudioResourceVersion: 0,
+			isCurrentClipMuted: false,
+			getSourceTrackPreviewGain: () => 1,
+			onSourceFallbackLoadError: vi.fn(),
+		});
+		await Promise.resolve();
+		expect(elements).toHaveLength(1);
+		expect(elements[0].currentTime).toBe(expected);
+	});
+});

--- a/src/components/video-editor/audio/useAudioPreviewSync.test.ts
+++ b/src/components/video-editor/audio/useAudioPreviewSync.test.ts
@@ -1,19 +1,100 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveMediaElementSource } from "@/lib/exporter/localMediaSource";
 import { useAudioPreviewSync } from "./useAudioPreviewSync";
 
+const hooks = vi.hoisted(() => ({
+	refs: [] as Array<{ current: unknown }>,
+	index: 0,
+	effects: [] as Array<() => unknown>,
+}));
 vi.mock("react", () => ({
 	useMemo: (fn: () => unknown) => fn(),
 	useCallback: (fn: unknown) => fn,
-	useRef: (current: unknown) => ({ current }),
+	useRef: (current: unknown) => {
+		const index = hooks.index++;
+		hooks.refs[index] ??= { current };
+		return hooks.refs[index];
+	},
 	useEffect: (fn: () => unknown) => {
-		fn();
+		hooks.effects.push(fn);
 	},
 }));
-vi.mock("@/lib/exporter/localMediaSource", () => ({
-	resolveMediaElementSource: async (src: string) => ({ src, revoke: () => {} }),
-}));
+vi.mock("@/lib/exporter/localMediaSource", () => ({ resolveMediaElementSource: vi.fn() }));
 
-afterEach(() => vi.unstubAllGlobals());
+class PreviewAudio {
+	currentTime = 0;
+	duration = 10;
+	paused = true;
+	src = "";
+	dataset = {};
+	play = vi.fn(async () => {
+		this.paused = false;
+	});
+	load() {}
+	pause() {
+		this.paused = true;
+	}
+}
+const elements: PreviewAudio[] = [];
+const audioPath = "/recording.mic.m4a";
+type Params = Parameters<typeof useAudioPreviewSync>[0];
+function render(overrides: Partial<Params> = {}) {
+	hooks.index = 0;
+	hooks.effects = [];
+	const result = useAudioPreviewSync({
+		audioRegions: [],
+		previewVolume: 1,
+		isPlaying: false,
+		currentTime: 3,
+		timelineTime: 3,
+		duration: 10,
+		effectiveSpeedRegions: [],
+		previewSourceAudioFallbackPaths: [audioPath],
+		sourceAudioFallbackStartDelayMsByPath: {},
+		sourceAudioResourceVersion: 0,
+		isCurrentClipMuted: false,
+		getSourceTrackPreviewGain: () => 1,
+		onSourceFallbackLoadError: vi.fn(),
+		...overrides,
+	});
+	for (const effect of hooks.effects) effect();
+	return result;
+}
+async function flushLoads() {
+	for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+beforeEach(() => {
+	hooks.refs = [];
+	elements.length = 0;
+	vi.mocked(resolveMediaElementSource).mockImplementation(async (src) => ({
+		src,
+		revoke: () => {},
+	}));
+	vi.stubGlobal(
+		"Audio",
+		class extends PreviewAudio {
+			constructor() {
+				super();
+				elements.push(this);
+			}
+		},
+	);
+	vi.stubGlobal(
+		"AudioContext",
+		class {
+			state = "running";
+			destination = {};
+			createGain() {
+				return { gain: { value: 1 }, connect() {} };
+			}
+		},
+	);
+});
+afterEach(() => {
+	vi.unstubAllGlobals();
+	vi.clearAllMocks();
+});
 
 describe("companion preview timing", () => {
 	it.each([
@@ -24,40 +105,93 @@ describe("companion preview timing", () => {
 		{ suffix: "mic", delay: -100, expected: 3 },
 		{ suffix: "mic", delay: 4000, expected: 0 },
 	])("seeks $suffix with recorded delay $delay ms", async ({ suffix, delay, expected }) => {
-		const elements: Array<{ currentTime: number }> = [];
+		const path = `/recording.${suffix}.m4a`;
+		render({
+			previewSourceAudioFallbackPaths: [path],
+			sourceAudioFallbackStartDelayMsByPath: delay === undefined ? {} : { [path]: delay },
+		});
+		await flushLoads();
+		expect(elements).toHaveLength(1);
+		expect(elements[0].currentTime).toBe(expected);
+	});
+
+	it.each([
+		false,
+		true,
+	])("waits for the recorded start time (initially playing: %s)", async (initiallyPlaying) => {
+		const timing = { [audioPath]: 2000 };
+		const controls = render({
+			isPlaying: initiallyPlaying,
+			currentTime: 1,
+			sourceAudioFallbackStartDelayMsByPath: timing,
+		});
+		await flushLoads();
+		controls.playSourceAudioPreview();
+		expect(elements[0].play).not.toHaveBeenCalled();
+		render({ isPlaying: true, currentTime: 1, sourceAudioFallbackStartDelayMsByPath: timing });
+		await flushLoads();
+		expect(elements[0].paused).toBe(true);
+		expect(elements[0].play).not.toHaveBeenCalled();
+		render({
+			isPlaying: true,
+			currentTime: 2.1,
+			sourceAudioFallbackStartDelayMsByPath: timing,
+		});
+		await flushLoads();
+		expect(elements[0].paused).toBe(false);
+		expect(elements[0].currentTime).toBeCloseTo(0.1);
+	});
+
+	it("does not play a late resource after playback has paused", async () => {
+		let resolve!: (value: { src: string; revoke: () => void }) => void;
+		vi.mocked(resolveMediaElementSource).mockReturnValue(
+			new Promise((done) => {
+				resolve = done;
+			}),
+		);
+		render({ isPlaying: true });
+		render({ isPlaying: false });
+		resolve({ src: audioPath, revoke: () => {} });
+		await flushLoads();
+		expect(elements[0].paused).toBe(true);
+		expect(elements[0].play).not.toHaveBeenCalled();
+	});
+
+	it("does not restart audio when a pending context resume finishes after pausing", async () => {
+		let resume!: () => void;
+		const pending = new Promise<void>((done) => {
+			resume = done;
+		});
 		vi.stubGlobal(
-			"Audio",
+			"AudioContext",
 			class {
-				currentTime = 0;
-				duration = 10;
-				paused = true;
-				dataset = {};
-				load() {}
-				pause() {}
-				constructor() {
-					elements.push(this);
+				state = "suspended";
+				destination = {};
+				resume() {
+					return pending;
+				}
+				createGain() {
+					return { gain: { value: 1 }, connect() {} };
 				}
 			},
 		);
-		const audioPath = `/recording.${suffix}.m4a`;
-		useAudioPreviewSync({
-			audioRegions: [],
-			previewVolume: 1,
-			isPlaying: false,
-			currentTime: 3,
-			timelineTime: 3,
-			duration: 10,
-			effectiveSpeedRegions: [],
-			previewSourceAudioFallbackPaths: [audioPath],
-			sourceAudioFallbackStartDelayMsByPath:
-				delay === undefined ? {} : { [audioPath]: delay },
-			sourceAudioResourceVersion: 0,
-			isCurrentClipMuted: false,
-			getSourceTrackPreviewGain: () => 1,
-			onSourceFallbackLoadError: vi.fn(),
-		});
-		await Promise.resolve();
-		expect(elements).toHaveLength(1);
-		expect(elements[0].currentTime).toBe(expected);
+		render({ isPlaying: true });
+		await flushLoads();
+		render({ isPlaying: false });
+		const callsBeforeResume = elements[0].play.mock.calls.length;
+		resume();
+		await flushLoads();
+		expect(elements[0].paused).toBe(true);
+		expect(elements[0].play).toHaveBeenCalledTimes(callsBeforeResume);
+	});
+
+	it("does not start an ended companion from the playback button", async () => {
+		const controls = render({ currentTime: 10 });
+		await flushLoads();
+		controls.playSourceAudioPreview();
+		render({ isPlaying: true, currentTime: 10 });
+		await flushLoads();
+		expect(elements[0].paused).toBe(true);
+		expect(elements[0].play).not.toHaveBeenCalled();
 	});
 });

--- a/src/components/video-editor/audio/useAudioPreviewSync.test.ts
+++ b/src/components/video-editor/audio/useAudioPreviewSync.test.ts
@@ -38,7 +38,7 @@ class PreviewAudio {
 const elements: PreviewAudio[] = [];
 const audioPath = "/recording.mic.m4a";
 type Params = Parameters<typeof useAudioPreviewSync>[0];
-function render(overrides: Partial<Params> = {}) {
+function render(overrides: Partial<Params> = {}, commit = true) {
 	hooks.index = 0;
 	hooks.effects = [];
 	const result = useAudioPreviewSync({
@@ -57,7 +57,9 @@ function render(overrides: Partial<Params> = {}) {
 		onSourceFallbackLoadError: vi.fn(),
 		...overrides,
 	});
-	for (const effect of hooks.effects) effect();
+	if (commit) {
+		for (const effect of hooks.effects) effect();
+	}
 	return result;
 }
 async function flushLoads() {
@@ -155,6 +157,32 @@ describe("companion preview timing", () => {
 		await flushLoads();
 		expect(elements[0].paused).toBe(true);
 		expect(elements[0].play).not.toHaveBeenCalled();
+	});
+
+	it.each([
+		false,
+		true,
+	])("ignores uncommitted playback state when a resource resolves (committed playing: %s)", async (isPlaying) => {
+		let resolve!: (value: { src: string; revoke: () => void }) => void;
+		vi.mocked(resolveMediaElementSource).mockReturnValue(
+			new Promise((done) => {
+				resolve = done;
+			}),
+		);
+		render({ isPlaying, currentTime: 1 });
+
+		// React may discard this render without running any of its effects.
+		render({ isPlaying: !isPlaying, currentTime: 5 }, false);
+		resolve({ src: audioPath, revoke: () => {} });
+		await flushLoads();
+		expect(elements[0].currentTime).toBe(1);
+		expect(elements[0].paused).toBe(!isPlaying);
+
+		// A subsequent committed update must still publish the new callback.
+		render({ isPlaying: !isPlaying, currentTime: 5 });
+		await flushLoads();
+		expect(elements[0].currentTime).toBe(5);
+		expect(elements[0].paused).toBe(isPlaying);
 	});
 
 	it("does not restart audio when a pending context resume finishes after pausing", async () => {

--- a/src/components/video-editor/audio/useAudioPreviewSync.ts
+++ b/src/components/video-editor/audio/useAudioPreviewSync.ts
@@ -79,6 +79,7 @@ export function useAudioPreviewSync({
 	const sourceAudioMasterGainRef = useRef<GainNode | null>(null);
 	const sourceAudioResumePromiseRef = useRef<Promise<void> | null>(null);
 	const lastSourceAudioSyncTimeRef = useRef<number | null>(null);
+	const syncSourceAudioRef = useRef<() => void>(() => undefined);
 
 	const ensureSourceAudioContext = useCallback(() => {
 		if (!sourceAudioContextRef.current) {
@@ -110,10 +111,8 @@ export function useAudioPreviewSync({
 
 	const playSourceAudioPreview = useCallback(() => {
 		void ensureSourceAudioRunning();
-		for (const audio of sourceAudioElementsRef.current.values()) {
-			if (!audio.src) continue;
-			audio.play().catch(() => undefined);
-		}
+		// Unlock the context during the user gesture. Timeline sync owns playback,
+		// including delayed starts and pauses while an audio resource is loading.
 	}, [ensureSourceAudioRunning]);
 
 	useEffect(() => {
@@ -241,9 +240,7 @@ export function useAudioPreviewSync({
 							sourceAudioResourceVersion,
 						);
 						latestAudio.load();
-						if (isPlaying) {
-							playSourceAudioPreview();
-						}
+						syncSourceAudioRef.current();
 					} catch (error) {
 						const latestAudio = existing.get(audioPath);
 						if (
@@ -289,13 +286,11 @@ export function useAudioPreviewSync({
 		}
 	}, [
 		getSourceTrackPreviewGain,
-		isPlaying,
 		isCurrentClipMuted,
 		onSourceFallbackLoadError,
 		resolvedSourceTracks,
 		sourceAudioResourceVersion,
 		previewVolume,
-		playSourceAudioPreview,
 	]);
 
 	useEffect(() => {
@@ -380,7 +375,7 @@ export function useAudioPreviewSync({
 		}
 	}, [effectiveSpeedRegions, isPlaying, resolvedUserTracks, timelineTime]);
 
-	useEffect(() => {
+	const syncSourceAudio = useCallback(() => {
 		if (resolvedSourceTracks.length === 0) {
 			lastSourceAudioSyncTimeRef.current = null;
 			return;
@@ -460,10 +455,11 @@ export function useAudioPreviewSync({
 			}
 
 			const atEnd = audioDuration !== null && targetTime >= audioDuration;
-			if (isPlaying && !beforeAudioStart && !atEnd) {
-				void ensureSourceAudioRunning().then(() => {
-					audio.play().catch(() => undefined);
-				});
+			if (isPlaying && !beforeAudioStart && !atEnd && audio.src) {
+				void ensureSourceAudioRunning();
+				if (audio.paused) {
+					void audio.play().catch(() => undefined);
+				}
 			} else if (!audio.paused) {
 				audio.pause();
 			}
@@ -483,18 +479,9 @@ export function useAudioPreviewSync({
 		ensureSourceAudioRunning,
 	]);
 
-	useEffect(() => {
-		if (!isPlaying || resolvedSourceTracks.length === 0) {
-			return;
-		}
-		void ensureSourceAudioRunning().then(() => {
-			for (const audio of sourceAudioElementsRef.current.values()) {
-				if (audio.paused) {
-					audio.play().catch(() => undefined);
-				}
-			}
-		});
-	}, [isPlaying, resolvedSourceTracks.length, ensureSourceAudioRunning]);
+	// Async resource loads must use the latest play/pause state and playhead.
+	syncSourceAudioRef.current = syncSourceAudio;
+	useEffect(syncSourceAudio, [syncSourceAudio]);
 
 	return { playSourceAudioPreview };
 }

--- a/src/components/video-editor/audio/useAudioPreviewSync.ts
+++ b/src/components/video-editor/audio/useAudioPreviewSync.ts
@@ -479,9 +479,11 @@ export function useAudioPreviewSync({
 		ensureSourceAudioRunning,
 	]);
 
-	// Async resource loads must use the latest play/pause state and playhead.
-	syncSourceAudioRef.current = syncSourceAudio;
-	useEffect(syncSourceAudio, [syncSourceAudio]);
+	// Async resource loads must only observe committed playback state.
+	useEffect(() => {
+		syncSourceAudioRef.current = syncSourceAudio;
+		syncSourceAudio();
+	}, [syncSourceAudio]);
 
 	return { playSourceAudioPreview };
 }

--- a/src/components/video-editor/audio/useAudioPreviewSync.ts
+++ b/src/components/video-editor/audio/useAudioPreviewSync.ts
@@ -422,14 +422,18 @@ export function useAudioPreviewSync({
 				sourceAudioFallbackStartDelayMsByPath[sourceAudioPath],
 			);
 			const maxPreviewStartDelaySeconds = isMicCompanionTrack ? 2 : 5;
-			const startDelaySeconds = isMicCompanionTrack
-				? 0
-				: Number.isFinite(duration) &&
-						(rawStartDelaySeconds >= Math.max(0, duration - 0.01) ||
-							rawStartDelaySeconds >
-								Math.max(maxPreviewStartDelaySeconds, duration * 0.9))
-					? 0
-					: rawStartDelaySeconds;
+			const recordedStartDelayMs = sourceAudioFallbackStartDelayMsByPath[sourceAudioPath];
+			const startDelaySeconds =
+				Number.isFinite(recordedStartDelayMs) && recordedStartDelayMs >= 0
+					? rawStartDelaySeconds
+					: isMicCompanionTrack
+						? 0
+						: Number.isFinite(duration) &&
+								(rawStartDelaySeconds >= Math.max(0, duration - 0.01) ||
+									rawStartDelaySeconds >
+										Math.max(maxPreviewStartDelaySeconds, duration * 0.9))
+							? 0
+							: rawStartDelaySeconds;
 			const beforeAudioStart = currentTime + 0.001 < startDelaySeconds;
 			const targetTime = clampMediaTimeToDuration(
 				currentTime - startDelaySeconds,

--- a/src/lib/exporter/audioEncoder.test.ts
+++ b/src/lib/exporter/audioEncoder.test.ts
@@ -89,6 +89,25 @@ describe("AudioProcessor offline render preparation", () => {
 		expect(decodeAudioFromUrl).not.toHaveBeenCalledWith("/tmp/recording.mp4");
 	});
 
+	it("does not decode an embedded microphone again when its companion replaces it", async () => {
+		const processor = new AudioProcessor() as unknown as OfflineRenderTestHarness;
+		const micBuffer = { duration: 10, numberOfChannels: 1 } as AudioBuffer;
+		const decode = vi.spyOn(processor, "decodeAudioFromUrl").mockResolvedValue(micBuffer);
+		vi.spyOn(processor, "getMediaDurationSec").mockResolvedValue(10);
+		const prepared = await processor.prepareOfflineRender(
+			"file:///tmp/recording.mp4",
+			[],
+			[],
+			[],
+			["/tmp/recording.mic.m4a"],
+		);
+		expect(prepared.mainBufferEntry).toBeNull();
+		expect(prepared.companionEntries).toHaveLength(1);
+		expect(prepared.companionEntries[0].gain).toBe(1);
+		expect(decode).toHaveBeenCalledTimes(1);
+		expect(decode).toHaveBeenCalledWith("/tmp/recording.mic.m4a");
+	});
+
 	it("does not treat a single embedded fallback path as an external sidecar", async () => {
 		const processor = new AudioProcessor() as unknown as OfflineRenderTestHarness;
 		const loadAudioFileDemuxer = vi.spyOn(processor, "loadAudioFileDemuxer");
@@ -115,6 +134,7 @@ describe("AudioProcessor offline render preparation", () => {
 		const processor = new AudioProcessor() as unknown as OfflineRenderTestHarness;
 		const mainBuffer = { duration: 600, numberOfChannels: 2 } as AudioBuffer;
 		const micBuffer = { duration: 565, numberOfChannels: 1 } as AudioBuffer;
+		vi.spyOn(processor, "getMediaDurationSec").mockResolvedValue(600);
 
 		vi.spyOn(processor, "decodeAudioFromUrl").mockImplementation(async (url: string) => {
 			if (url === "file:///tmp/recording.mp4") {
@@ -161,7 +181,28 @@ describe("AudioProcessor offline render preparation", () => {
 		expect(renderAndMuxOfflineAudio).toHaveBeenCalled();
 	});
 
-	it("avoids the single-sidecar fast path for legacy mac mic sidecars that still need embedded audio", async () => {
+	it.each([
+		"mic",
+		"system",
+	])("renders a native mac %s companion instead of using the demux fast path", async (track) => {
+		const processor = new AudioProcessor() as unknown as OfflineRenderTestHarness;
+		const loadDemuxer = vi.spyOn(processor, "loadAudioFileDemuxer");
+		const render = vi.spyOn(processor, "renderAndMuxOfflineAudio").mockResolvedValue();
+		await processor.process(
+			null,
+			{} as never,
+			"file:///tmp/recording.mp4",
+			[],
+			[],
+			undefined,
+			[],
+			[`/tmp/recording.${track}.m4a`],
+		);
+		expect(loadDemuxer).not.toHaveBeenCalled();
+		expect(render).toHaveBeenCalled();
+	});
+
+	it("mixes a mic companion when embedded audio is explicitly selected", async () => {
 		const processor = new AudioProcessor() as unknown as OfflineRenderTestHarness;
 		const loadAudioFileDemuxer = vi.spyOn(processor, "loadAudioFileDemuxer");
 		const renderAndMuxOfflineAudio = vi
@@ -176,7 +217,7 @@ describe("AudioProcessor offline render preparation", () => {
 			[],
 			undefined,
 			[],
-			["/tmp/recording.mic.m4a"],
+			["/tmp/recording.mp4", "/tmp/recording.mic.m4a"],
 		);
 
 		expect(loadAudioFileDemuxer).not.toHaveBeenCalled();

--- a/src/lib/exporter/audioEncoder.ts
+++ b/src/lib/exporter/audioEncoder.ts
@@ -263,18 +263,18 @@ export class AudioProcessor {
 			videoUrl,
 			sortedSourceAudioFallbackPaths,
 		);
-		const requiresLegacyMacMicSidecarMix =
-			routingPolicy.includeEmbeddedInExport &&
-			!routingPolicy.hasEmbeddedSourceAudio &&
-			routingPolicy.playbackPaths.length === 1 &&
-			routingPolicy.playbackPaths[0]?.toLowerCase().endsWith(".mic.m4a") === true;
+		// Native macOS M4A companions need offline rendering; the single-sidecar
+		// demux fast path can yield no AAC samples for these recordings.
+		const requiresNativeMacCompanionRender = routingPolicy.playbackPaths.some((audioPath) =>
+			/\.(mic|system)\.m4a$/i.test(audioPath),
+		);
 		const hasTimedCompanionAudio = routingPolicy.playbackPaths.some(
 			(audioPath) => (sourceAudioFallbackStartDelayMsByPath?.[audioPath] ?? 0) > 0,
 		);
 		const needsSourceAudioMixing =
 			routingPolicy.playbackPaths.length > 1 ||
 			(routingPolicy.hasEmbeddedSourceAudio && routingPolicy.playbackPaths.length > 0) ||
-			requiresLegacyMacMicSidecarMix ||
+			requiresNativeMacCompanionRender ||
 			hasTimedCompanionAudio;
 
 		// When speed edits, audio regions, or multiple audio sources need mixing, use offline AudioContext pipeline.

--- a/src/lib/exporter/audioRoutingEngine.ts
+++ b/src/lib/exporter/audioRoutingEngine.ts
@@ -68,7 +68,12 @@ export function buildResolvedAudioPlan(input: {
 	if (pathsByTrack.mic) playbackPaths.push(pathsByTrack.mic);
 	if (!hasDedicatedTracks && pathsByTrack.mixed) playbackPaths.push(pathsByTrack.mixed);
 
-	const includeEmbeddedInExport = !pathsByTrack.system && !pathsByTrack.mixed;
+	// A mic-only selection replaces embedded audio unless the selector explicitly
+	// included the video (for example, Windows system audio plus a mic sidecar).
+	const includeEmbeddedInExport =
+		!pathsByTrack.system &&
+		!pathsByTrack.mixed &&
+		(!pathsByTrack.mic || hasEmbeddedSourceAudio);
 	const resolvedRegions = (input.audioRegions ?? [])
 		.slice()
 		.sort((a, b) => a.startMs - b.startMs);

--- a/src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts
+++ b/src/lib/exporter/modernVideoExporter.nativeStaticLayout.test.ts
@@ -150,18 +150,31 @@ describe("ModernVideoExporter native static-layout eligibility", () => {
 		});
 	});
 
-	it("mixes companion sidecar audio when the source MP4 also has an audio track", () => {
+	it("mixes companion sidecar audio when the source MP4 is explicitly selected", () => {
 		const videoPath = "C:\\recordly\\recording.mp4";
 		const micPath = "C:\\recordly\\recording.mic.wav";
 		const exporter = createExporter({
 			videoUrl: `file:///${videoPath.replace(/\\/g, "/")}`,
-			sourceAudioFallbackPaths: [micPath],
+			sourceAudioFallbackPaths: [videoPath, micPath],
 		});
 
 		expect(exporter.buildNativeAudioPlan(videoInfo)).toMatchObject({
 			audioMode: "edited-track",
 			strategy: "offline-render-fallback",
 			sourceAudioFallbackPaths: [expect.stringMatching(/recording\.mp4$/), micPath],
+		});
+	});
+
+	it.each([
+		"m4a",
+		"webm",
+	])("does not add embedded audio back to a mic replacement (%s)", (extension) => {
+		const micPath = `/recording.mic.${extension}`;
+		const exporter = createExporter({ sourceAudioFallbackPaths: [micPath] });
+		expect(exporter.buildNativeAudioPlan(videoInfo)).toEqual({
+			audioMode: "edited-track",
+			strategy: "offline-render-fallback",
+			sourceAudioFallbackPaths: [micPath],
 		});
 	});
 

--- a/src/lib/exporter/modernVideoExporter.ts
+++ b/src/lib/exporter/modernVideoExporter.ts
@@ -1237,26 +1237,6 @@ export class ModernVideoExporter {
 		return buildNativeStaticLayoutTimelineSegments(sourceSegments);
 	}
 
-	private getNativeAudioFallbackPaths(videoInfo: DecodedVideoInfo): string[] {
-		const sourceAudioFallbackPaths = (this.config.sourceAudioFallbackPaths ?? []).filter(
-			(audioPath) => typeof audioPath === "string" && audioPath.trim().length > 0,
-		);
-		const localVideoSourcePath = this.getNativeVideoSourcePath();
-		if (!videoInfo.hasAudio || !localVideoSourcePath) {
-			return sourceAudioFallbackPaths;
-		}
-
-		const { externalAudioPaths } = resolveSourceAudioFallbackPaths(
-			localVideoSourcePath,
-			sourceAudioFallbackPaths,
-		);
-		if (externalAudioPaths.length === 0) {
-			return sourceAudioFallbackPaths;
-		}
-
-		return [localVideoSourcePath, ...externalAudioPaths];
-	}
-
 	private shouldUseNativeStaticLayoutTimelineMap(
 		videoInfo: DecodedVideoInfo,
 		effectiveDurationSec: number,
@@ -1276,12 +1256,26 @@ export class ModernVideoExporter {
 	private buildNativeAudioPlan(videoInfo: DecodedVideoInfo): NativeAudioPlan {
 		const speedRegions = this.config.speedRegions ?? [];
 		const audioRegions = this.config.audioRegions ?? [];
-		const sourceAudioFallbackPaths = this.getNativeAudioFallbackPaths(videoInfo);
+		const sourceAudioFallbackPaths = (this.config.sourceAudioFallbackPaths ?? []).filter(
+			(audioPath) => typeof audioPath === "string" && audioPath.trim().length > 0,
+		);
 		const hasTimedSourceAudioFallback = sourceAudioFallbackPaths.some(
 			(audioPath) =>
 				(this.config.sourceAudioFallbackStartDelayMsByPath?.[audioPath] ?? 0) > 0,
 		);
 		const localVideoSourcePath = this.getNativeVideoSourcePath();
+		const { externalAudioPaths } = resolveSourceAudioFallbackPaths(
+			localVideoSourcePath,
+			sourceAudioFallbackPaths,
+		);
+		if (videoInfo.hasAudio && externalAudioPaths.length > 0) {
+			// Preserve the selector's replacement/supplemental audio decision.
+			return {
+				audioMode: "edited-track",
+				strategy: "offline-render-fallback",
+				sourceAudioFallbackPaths,
+			};
+		}
 		const primaryAudioSourcePath =
 			(videoInfo.hasAudio ? localVideoSourcePath : null) ??
 			sourceAudioFallbackPaths[0] ??

--- a/src/lib/exporter/sourceTrackRoutingPolicy.test.ts
+++ b/src/lib/exporter/sourceTrackRoutingPolicy.test.ts
@@ -38,4 +38,21 @@ describe("resolveSourceTrackRoutingPolicy", () => {
 		expect(policy.muteEmbeddedPreview).toBe(false);
 		expect(policy.includeEmbeddedInExport).toBe(true);
 	});
+	it.each([
+		"m4a",
+		"webm",
+		"wav",
+	])("uses a selected mic companion as replacement audio (%s)", (extension) => {
+		const micPath = `/tmp/recording.mic.${extension}`;
+		const policy = resolveSourceTrackRoutingPolicy("/tmp/recording.mp4", [micPath]);
+		expect(policy.playbackPaths).toEqual([micPath]);
+		expect(policy.muteEmbeddedPreview).toBe(true);
+		expect(policy.includeEmbeddedInExport).toBe(false);
+	});
+
+	it("keeps embedded-only playback when no companion was selected", () => {
+		const policy = resolveSourceTrackRoutingPolicy("/tmp/recording.mp4", []);
+		expect(policy.muteEmbeddedPreview).toBe(false);
+		expect(policy.includeEmbeddedInExport).toBe(true);
+	});
 });

--- a/src/lib/exporter/videoExporter.audioPlan.test.ts
+++ b/src/lib/exporter/videoExporter.audioPlan.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import { VideoExporter } from "./videoExporter";
+import type { DecodedVideoInfo } from "./streamingDecoder";
+
+const videoInfo: DecodedVideoInfo = {
+	width: 1920,
+	height: 1080,
+	duration: 10,
+	streamDuration: 10,
+	frameRate: 30,
+	codec: "h264",
+	hasAudio: true,
+	audioCodec: "aac",
+	audioSampleRate: 48_000,
+};
+
+function audioPlan(paths: string[], info = videoInfo, delays: Record<string, number> = {}) {
+	const exporter = new VideoExporter({
+		videoUrl: "file:///recording.mp4",
+		sourceAudioFallbackPaths: paths,
+		sourceAudioFallbackStartDelayMsByPath: delays,
+	} as never) as unknown as { buildNativeAudioPlan: (info: DecodedVideoInfo) => unknown };
+	return exporter.buildNativeAudioPlan(info);
+}
+
+describe("VideoExporter native companion audio routing", () => {
+	it.each([
+		["/recording.system.m4a", "/recording.mic.m4a"],
+		["/recording.system.m4a"],
+		["/recording.mic.m4a"],
+	])("renders sidecars through the shared routing policy: %j", (...paths) => {
+		expect(audioPlan(paths)).toEqual({
+			audioMode: "edited-track",
+			strategy: "offline-render-fallback",
+		});
+	});
+
+	it("preserves embedded-only recordings", () => {
+		expect(audioPlan([])).toMatchObject({
+			audioMode: "copy-source",
+			audioSourcePath: "/recording.mp4",
+		});
+		expect(audioPlan(["/recording.mp4"])).toMatchObject({
+			audioMode: "copy-source",
+			audioSourcePath: "/recording.mp4",
+		});
+	});
+
+	it("copies an untimed sidecar when there is no embedded audio", () => {
+		expect(
+			audioPlan(["/recording.system.m4a"], { ...videoInfo, hasAudio: false }),
+		).toMatchObject({
+			audioMode: "copy-source",
+			audioSourcePath: "/recording.system.m4a",
+		});
+	});
+
+	it("renders timed sidecars instead of losing their offset", () => {
+		expect(
+			audioPlan(
+				["/recording.mic.m4a"],
+				{ ...videoInfo, hasAudio: false },
+				{ "/recording.mic.m4a": 125 },
+			),
+		).toEqual({
+			audioMode: "edited-track",
+			strategy: "offline-render-fallback",
+		});
+	});
+});

--- a/src/lib/exporter/videoExporter.ts
+++ b/src/lib/exporter/videoExporter.ts
@@ -1,3 +1,4 @@
+import { resolveSourceAudioFallbackPaths } from "./sourceAudioFallback";
 import type {
 	AnnotationRegion,
 	AudioRegion,
@@ -552,6 +553,15 @@ export class VideoExporter {
 				(this.config.sourceAudioFallbackStartDelayMsByPath?.[audioPath] ?? 0) > 0,
 		);
 		const localVideoSourcePath = this.getNativeVideoSourcePath();
+		const { externalAudioPaths } = resolveSourceAudioFallbackPaths(
+			localVideoSourcePath,
+			sourceAudioFallbackPaths,
+		);
+		if (videoInfo.hasAudio && externalAudioPaths.length > 0) {
+			// Use the shared routing policy even for one sidecar, rather than copying
+			// an embedded stream that may be silent or missing the microphone.
+			return { audioMode: "edited-track", strategy: "offline-render-fallback" };
+		}
 		const primaryAudioSourcePath =
 			(videoInfo.hasAudio ? localVideoSourcePath : null) ??
 			sourceAudioFallbackPaths[0] ??


### PR DESCRIPTION
## Description

Preserve companion microphone audio through preview and export without mixing an already embedded microphone twice.

Upstream #913 now provides the macOS sidecar selection fix on `main`. This PR builds on that implementation and fixes how the selected tracks are consumed:

- Respect the selected source list: `[mic]` replaces embedded audio, while `[video, mic]` explicitly mixes supplemental microphone audio. Both preview and export follow this policy, including older recordings that retain a mic sidecar alongside an already embedded microphone.
- Preserve the source selection in both native export planners instead of copying or adding back the MP4 implicitly. Render native M4A companions offline to avoid empty audio from the single-sidecar demux fast path.
- Honor explicit `startDelayMs` metadata. Timeline synchronization owns companion playback; playback-button callbacks only unlock the audio context, and late resource loads use committed timeline state. Pending context resumes cannot restart paused audio.
- Publish the synchronization callback ref in a commit-phase effect so discarded renders cannot leak uncommitted play, pause, or seek state into pending resource loads.

The discovery implementation and its documentation match upstream. Additional discovery tests cover missing, single, and mixed-format companions and timing metadata. No companion files still means ordinary embedded-audio playback; explicit Windows system-plus-microphone selections remain supported. No capture, permission, project-format, or dependency changes.

## Motivation

Returning the right companion paths is only the first step. Native export planners can still copy or implicitly re-add the embedded MP4, and a microphone companion may then be omitted or mixed with an already embedded copy. Preview also needs to honor delayed starts across every playback entry point and keep asynchronous loads aligned with committed React state.

## Type of Change

- [x] Bug Fix

## Testing Guide

Automated validation:

- `npm test`: 123 test files and 1,123 tests passed.
- Regression coverage includes companion selection, replacement versus supplemental microphone audio, both native export planners, M4A offline rendering, explicit delays, active playback before the delay, late resource loads after pausing, pending context resumes, and ended companions.
- The two self-review counterexamples failed before these fixes and now pass.
- Two additional regression cases simulate discarded play/pause and seek renders while an audio resource is loading. The callback ref is published only in a commit-phase effect; uncommitted state cannot reach the resource continuation.
- TypeScript, Biome lint for changed files, Vite/CJS build smoke checks, packaged-binary checks, and deep macOS signature verification passed.

Local end-to-end validation:

- The user confirmed audible playback of an affected recording in the actual editor.
- Modern WebCodecs, Modern native, Legacy native, and the Legacy WebCodecs fallback were exercised. The Legacy fallback was triggered by simulating unavailable native export in the test process only.
- A synthetic recording with identical embedded and companion microphone audio now exports at the source level: RMS differences are approximately 0.002 dB for native export and 0.092 dB for WebCodecs, rather than the approximately 14.36 dB attenuation reproduced before the fix.
- Actual preview of a two-second delayed mic kept the video muted and the mic paused before its start; playback began within one frame of two seconds.
- A system-only M4A companion was also verified through actual WebCodecs export.
- Coverage includes both companions, mic only, system only, an MP4 without audio, no companions, legacy WebM, mixed M4A/WebM, and timing metadata.
- A new recording of approximately 10.9 seconds captured microphone input and a known system notification sound. Both companion tracks and its native export contained audio; fitted gains for both source tracks were approximately 1.00.

To reproduce the original issue, keep the MP4, `.system.m4a`, and `.mic.m4a` together and import the MP4. Preview and export should include the mic even when embedded audio is silent. Also test an already embedded mic with only its identical mic companion retained, and a mic companion with explicit delayed-start metadata.

Timing limitation: existing encoding and timing behavior on the original recordings showed fixed offsets of approximately 30–74 ms. This change does not claim sample-exact synchronization or recalibrate encoder delay.

## Related Issue(s)

No linked issue.

## Screenshots / Video

No visual UI changes. Audio behavior was verified using actual playback, playback-state measurements, and decoded export PCM.

## Checklist

- [x] Completed source self-review and addressed its findings.
- [x] Added regression tests and completed local end-to-end validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved source-audio preview synchronization so playback, seeking, and pause state remain consistent when media loads asynchronously.
  - Corrected handling of Mac microphone and system companion audio files, including recorded timing offsets.
  - Prevented empty or invalid companion files from being used.

- **Audio Export**
  - Improved replacement and mixing behavior for embedded audio and selected microphone companions.
  - Preserved embedded audio when appropriate and routed companion audio through rendering when required.
  - Maintained timing for both timed and untimed companion audio during export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

