### PR TITLE
fix(export): prefer the WebGL renderer on Linux

### DIFF
--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -638,14 +638,24 @@ export class FrameRenderer {
 		};
 
 		const preferredRenderBackend = this.config.preferredRenderBackend;
-		const backendOrder: ExportRenderBackend[] =
-			preferredRenderBackend === "webgl"
+		const webgpuRuntimeAvailable = typeof navigator !== "undefined" && "gpu" in navigator;
+		// On Linux the WebGPU export path is unreliable. Under a Wayland session
+		// Chromium reports "'--ozone-platform=wayland' is not compatible with
+		// Vulkan", Dawn comes up degraded, and the Pixi WebGPU bind group code then
+		// throws "Cannot read properties of undefined (reading '_resourceType')"
+		// partway through the export. WebGL through ANGLE works on both Wayland and
+		// X11, so prefer it there unless the caller explicitly asked for WebGPU.
+		const preferWebglOnThisPlatform =
+			typeof navigator !== "undefined" && /Linux/i.test(navigator.userAgent);
+		const backendOrder: ExportRenderBackend[] = !webgpuRuntimeAvailable
+			? ["webgl"]
+			: preferredRenderBackend === "webgl"
 				? ["webgl", "webgpu"]
 				: preferredRenderBackend === "webgpu"
 					? ["webgpu", "webgl"]
-					: typeof navigator !== "undefined" && "gpu" in navigator
-						? ["webgpu", "webgl"]
-						: ["webgl"];
+					: preferWebglOnThisPlatform
+						? ["webgl", "webgpu"]
+						: ["webgpu", "webgl"];
 		const failures: PixiRendererAttempt[] = [];
 
 		for (const backend of backendOrder) {


### PR DESCRIPTION
Fixes the Lightning export crash reported in #644.

## Root cause

`FrameRenderer.createPixiApplication` picks the backend order from a single
runtime check:

```ts
: typeof navigator !== "undefined" && "gpu" in navigator
    ? ["webgpu", "webgl"]
    : ["webgl"];
```

On Linux that check is not a good proxy for a usable WebGPU renderer. In a
Wayland session Chromium logs:

```
ERROR:ui/ozone/platform/wayland/gpu/wayland_surface_factory.cc:249]
'--ozone-platform=wayland' is not compatible with Vulkan.
Consider switching to '--ozone-platform=x11' or disabling Vulkan
```

`navigator.gpu` is still present and the adapter and device still resolve, so
the guard passes. I confirmed that from inside a packaged build over the
DevTools protocol:

```json
{"hasGPU":true,"webgl2":true,
 "glRenderer":"ANGLE (AMD, AMD Radeon Graphics (radeonsi rembrandt ACO), OpenGL ES 3.2)",
 "adapter":true,"adapterMs":109,
 "adapterInfo":{"vendor":"amd","arch":"rdna-2"},"device":true}
```

Dawn is nonetheless degraded, and the Pixi WebGPU bind group code later throws
`Cannot read properties of undefined (reading '_resourceType')` partway through
the export, which is exactly the message users see in #644. Because the Legacy
pipeline was removed, affected users now have no working export path at all.

## The change

Prefer WebGL on Linux. WebGL through ANGLE initialises and renders on both
Wayland and X11.

An explicit `preferredRenderBackend` still wins in both directions, so
`smokeRenderBackend=webgpu` and any future user-facing setting keep full
control. The `!webgpuRuntimeAvailable` branch keeps the old behaviour of not
attempting WebGPU at all when the runtime is missing.

macOS and Windows are untouched.

## Testing

- `npx biome check src/lib/exporter/modernFrameRenderer.ts` is clean.
- Built the equivalent change into a packaged Linux build from the `v1.4.0`
  tag with `npm run build:linux`, verified in the emitted bundle that the
  backend order is now WebGL first on Linux, and confirmed the app starts.
- Environment: Arch Linux, KDE Plasma 6.7.5 on Wayland, AMD Radeon 680M,
  Mesa 26.2.2, Recordly 1.4.0.

I could not verify a full successful export end to end before opening this,
because the bundled `smokeExport` harness starts with the GPU disabled
(`"webgl":"disabled_off"`, `"webgpu":"disabled_off"`, `gl=none,angle=none`) and
falls back to software rendering, so it does not exercise the failing path. If
that harness is meant to run with GPU acceleration, that looks like a separate
bug worth a look.

## Unrelated observation

While tracing this I noticed the Linux X11 path is also broken in 1.4.0. When
`XDG_SESSION_TYPE=x11`, the app appends `--use-gl=egl`, which Electron 43
rejects:

```
ERROR:ui/gl/init/gl_factory.cc:110] Requested GL implementation
(gl=egl-gles2,angle=none) not found in allowed implementations:
[(gl=egl-angle,angle=opengl),(gl=egl-angle,angle=opengles),(gl=egl-angle,angle=vulkan)]
ERROR: Exiting GPU process due to errors during initialization
```

The GPU process then dies on startup. Happy to open a separate issue for that
if useful.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved graphics backend selection for more reliable rendering on Linux, where WebGL is now prioritized by default when available.
  - Preserved explicit rendering preferences, including the ability to prioritize WebGPU on Linux.
  - Continued prioritizing WebGPU on supported non-Linux systems.
  - Maintained fallback behavior when the preferred rendering backend is unavailable, helping ensure graphics continue to initialize across supported environments.
  - Improved fallback handling on systems without WebGPU support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->