### PR TITLE
fix: disable mic AGC by default to stop Windows audio crackle

### DIFF
--- a/electron/ipc/register/settings.ts
+++ b/electron/ipc/register/settings.ts
@@ -21,7 +21,7 @@ import {
 import { parseJsonWithByteOrderMark } from "../utils";
 
 const BROWSER_MICROPHONE_PROFILE_ENV = "RECORDLY_BROWSER_MIC_PROFILE";
-const DEFAULT_BROWSER_MICROPHONE_PROFILE = "processed";
+const DEFAULT_BROWSER_MICROPHONE_PROFILE = "no-agc";
 const recordingPreferencesStore = createRecordingPreferencesStore(RECORDINGS_SETTINGS_FILE);
 const BROWSER_MICROPHONE_PROFILES = new Set([
 	"processed",

--- a/src/hooks/useScreenRecorder.test.ts
+++ b/src/hooks/useScreenRecorder.test.ts
@@ -34,12 +34,12 @@ function createMockMediaRecorder(initialState: RecordingState = "inactive") {
 }
 
 describe("createProcessedMicrophoneConstraints", () => {
-	it("requests browser voice processing with AGC for the default microphone", () => {
+	it("requests browser voice processing without AGC for the default microphone", () => {
 		expect(createProcessedMicrophoneConstraints()).toEqual({
 			audio: {
 				echoCancellation: true,
 				noiseSuppression: true,
-				autoGainControl: true,
+				autoGainControl: false,
 				channelCount: { ideal: 1 },
 				sampleRate: { ideal: 48000 },
 			},
@@ -53,7 +53,7 @@ describe("createProcessedMicrophoneConstraints", () => {
 				deviceId: { exact: "device-123" },
 				echoCancellation: true,
 				noiseSuppression: true,
-				autoGainControl: true,
+				autoGainControl: false,
 				channelCount: { ideal: 1 },
 				sampleRate: { ideal: 48000 },
 			},
@@ -105,10 +105,10 @@ describe("createProcessedMicrophoneConstraints", () => {
 		});
 	});
 
-	it("normalizes invalid lab microphone profiles to production voice processing", () => {
+	it("normalizes invalid lab microphone profiles to the default voice processing", () => {
 		expect(normalizeBrowserMicrophoneProfile("RAW")).toBe("raw");
-		expect(normalizeBrowserMicrophoneProfile("unknown")).toBe("processed");
-		expect(normalizeBrowserMicrophoneProfile(null)).toBe("processed");
+		expect(normalizeBrowserMicrophoneProfile("unknown")).toBe("no-agc");
+		expect(normalizeBrowserMicrophoneProfile(null)).toBe("no-agc");
 	});
 });
 

--- a/src/hooks/useScreenRecorder.ts
+++ b/src/hooks/useScreenRecorder.ts
@@ -51,7 +51,7 @@ export type BrowserCaptureCursorPolicy = {
 	hideOsCursorBeforeRecording: boolean;
 	hideEditorOverlayCursorByDefault: boolean;
 };
-const DEFAULT_BROWSER_MICROPHONE_PROFILE: BrowserMicrophoneProfile = "processed";
+const DEFAULT_BROWSER_MICROPHONE_PROFILE: BrowserMicrophoneProfile = "no-agc";
 const BROWSER_MICROPHONE_PROFILES = new Set<BrowserMicrophoneProfile>([
 	"processed",
 	"no-agc",


### PR DESCRIPTION
## Description
Default microphone recording on Windows to the `no-agc` browser voice-processing profile instead of `processed`, so Chromium's real-time Automatic Gain Control is off by default for the built-in mic fallback path.

## Motivation
Users recording with the built-in mic on Windows reported audio breaking up repeatedly with a low-pitched, garbled/unclear voice (e.g. saying "hello" comes out warbled and stuttered). Investigation traced this to Chromium's real-time AGC, which the team had already identified in prior beta testing as causing short crackle/dropout bursts on some Realtek and headset mic paths (see the existing comment in `electron/ipc/recording/audioFilters.ts`). A `no-agc` mitigation already existed in the code, but it was only reachable via a hidden environment variable (`RECORDLY_BROWSER_MIC_PROFILE`) that a normal downloaded build never sets — so every real user still hit the buggy `processed` default. Echo cancellation and noise suppression remain enabled; volume is restored after the fact via the existing offline `speechnorm`/`alimiter` filter chain instead of AGC's real-time loop.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
https://github.com/webadderallorg/Recordly/issues/931

## Screenshots / Video
N/A — audio-only backend behavior change, no UI change.

## Testing Guide
1. On Windows, enable the built-in/onboard mic and record a screen capture while speaking.
2. Confirm the recorded mic audio no longer breaks up, warbles, or drops in pitch.
3. Run unit tests:
   ```bash
   npx vitest run src/hooks/useScreenRecorder.test.ts electron/ipc/recording/audioFilters.test.ts
   ```
4. Confirm echo cancellation and noise suppression still audibly work (background hum/echo still suppressed), only AGC's real-time pumping is gone.

## Checklist
- [x] I have performed a self-review of my code.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the default browser microphone profile to disable automatic gain control (AGC).
  * Microphone recording now consistently uses the no-AGC profile when no valid profile is selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->