### PR TITLE
FIX:default to WebGL over WebGPU on Linux

### DIFF
--- a/src/lib/exporter/backendPolicy.test.ts
+++ b/src/lib/exporter/backendPolicy.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
 	getDefaultLightningRenderBackend,
+	getDefaultLightningRenderBackendOrder,
 	normalizeLightningRuntimePlatform,
 	planLightningExportRoutes,
 	shouldPreferNativeAutoBackend,
@@ -27,6 +28,13 @@ describe("backendPolicy", () => {
 		expect(getDefaultLightningRenderBackend()).toBe("webgl");
 	});
 
+	it("defaults Linux to WebGL first to avoid the WebGPU/Dawn resource-import crash", () => {
+		expect(getDefaultLightningRenderBackendOrder("linux")).toEqual(["webgl", "webgpu"]);
+		expect(getDefaultLightningRenderBackendOrder("win32")).toEqual(["webgpu", "webgl"]);
+		expect(getDefaultLightningRenderBackendOrder("darwin")).toEqual(["webgpu", "webgl"]);
+		expect(getDefaultLightningRenderBackendOrder("unknown")).toEqual(["webgpu", "webgl"]);
+	});
+	
 	it("keeps Windows auto exports on the streaming route by default", () => {
 		expect(shouldPreferNativeStaticLayoutBeforeBreeze("win32", "auto")).toBe(false);
 		expect(shouldPreferNativeStaticLayoutBeforeBreeze("darwin", "auto")).toBe(false);

--- a/src/lib/exporter/backendPolicy.ts
+++ b/src/lib/exporter/backendPolicy.ts
@@ -149,3 +149,12 @@ export function planLightningExportRoutes(options: {
 export function getDefaultLightningRenderBackend(): ExportRenderBackend {
 	return "webgl";
 }
+
+// WebGPU-on-Linux (Dawn/Vulkan) can corrupt GPU resource imports for VideoFrame-backed
+// textures mid-export, crashing PixiJS's WebGPU bind group system well after init
+// succeeds. Default Linux to WebGL until that upstream instability is resolved.
+export function getDefaultLightningRenderBackendOrder(
+	platform: LightningRuntimePlatform,
+): ExportRenderBackend[] {
+	return platform === "linux" ? ["webgl", "webgpu"] : ["webgpu", "webgl"];
+}

--- a/src/lib/exporter/modernFrameRenderer.ts
+++ b/src/lib/exporter/modernFrameRenderer.ts
@@ -86,6 +86,10 @@ import {
 	renderAnnotations,
 	renderAnnotationToCanvas,
 } from "./annotationRenderer";
+import {
+	getDefaultLightningRenderBackendOrder,
+	normalizeLightningRuntimePlatform,
+} from "./backendPolicy";
 import { ForwardFrameSource } from "./forwardFrameSource";
 import { resolveMediaElementSource } from "./localMediaSource";
 import {
@@ -638,13 +642,16 @@ export class FrameRenderer {
 		};
 
 		const preferredRenderBackend = this.config.preferredRenderBackend;
+		const runtimePlatform = normalizeLightningRuntimePlatform(
+			typeof navigator !== "undefined" ? navigator.platform || navigator.userAgent || "" : "",
+		);
 		const backendOrder: ExportRenderBackend[] =
 			preferredRenderBackend === "webgl"
 				? ["webgl", "webgpu"]
 				: preferredRenderBackend === "webgpu"
 					? ["webgpu", "webgl"]
 					: typeof navigator !== "undefined" && "gpu" in navigator
-						? ["webgpu", "webgl"]
+						? getDefaultLightningRenderBackendOrder(runtimePlatform)
 						: ["webgl"];
 		const failures: PixiRendererAttempt[] = [];
 


### PR DESCRIPTION

## Description
Changes the default render backend order for Lightning exports on Linux so that WebGL is tried before WebGPU, instead of the other way around.

## Motivation
On Linux, the WebGPU backend (Dawn/Vulkan) can corrupt GPU resource imports for VideoFrame-backed textures partway through an export. This crashes PixiJS's WebGPU bind group system well after initialization has already succeeded, so the failure isn't caught by existing init-time checks. Defaulting Linux to WebGL avoids this instability until it's resolved upstream, while other platforms keep preferring WebGPU.

## Type of Change
- [ ] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other (please specify)

## Related Issue(s)
N/A

## Screenshots / Video
N/A — this is an internal backend-selection change with no UI impact.

## Testing Guide
1. `npm test -- backendPolicy` — covers `getDefaultLightningRenderBackendOrder`, which returns `["webgl", "webgpu"]` on Linux and `["webgpu", "webgl"]` on other platforms.
2. On a Linux machine with a WebGPU-capable GPU, start an export and confirm it now runs on the WebGL backend by default (no explicit `preferredRenderBackend` override) and completes without the mid-export GPU resource crash.
3. On macOS/Windows, confirm export backend selection is unchanged (WebGPU still preferred when available).

## Checklist
- [x] I have performed a self-review of my code.
- [ ] I have added any necessary screenshots or videos.
- [ ] I have linked related issue(s) and updated the changelog if applicable.
---



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated Lightning export rendering to select a platform-specific backend order.
  - Linux systems now prioritize WebGL before WebGPU.
  - Windows, macOS, and other platforms continue to prioritize WebGPU before WebGL.
  - Rendering automatically falls back to the next available backend when needed.
  - Explicitly selected rendering backends continue to be respected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->