### PR TITLE
Use native WASAPI for Windows microphone recording

### DIFF
--- a/electron/ipc/recording/windowsFallbacks.test.ts
+++ b/electron/ipc/recording/windowsFallbacks.test.ts
@@ -7,9 +7,9 @@ import {
 } from "./windowsFallbacks";
 
 describe("shouldUseWindowsBrowserMicrophoneFallback", () => {
-	it("defaults Windows microphone capture to the browser fallback path", () => {
+	it("defaults Windows microphone capture to native WASAPI", () => {
 		expect(shouldStartWindowsBrowserMicrophoneFallback({ capturesMicrophone: true }, {})).toBe(
-			true,
+			false,
 		);
 	});
 
@@ -22,7 +22,7 @@ describe("shouldUseWindowsBrowserMicrophoneFallback", () => {
 		).toBe(true);
 	});
 
-	it("allows lab runs to force native WASAPI microphone capture", () => {
+	it("keeps native WASAPI enabled when explicitly requested", () => {
 		expect(
 			shouldStartWindowsBrowserMicrophoneFallback(
 				{ capturesMicrophone: true },
@@ -33,6 +33,15 @@ describe("shouldUseWindowsBrowserMicrophoneFallback", () => {
 			shouldStartWindowsBrowserMicrophoneFallback(
 				{ capturesMicrophone: true },
 				{ [WINDOWS_MIC_CAPTURE_MODE_ENV]: "wasapi" },
+			),
+		).toBe(false);
+	});
+
+	it("uses native WASAPI for unknown mode values", () => {
+		expect(
+			shouldStartWindowsBrowserMicrophoneFallback(
+				{ capturesMicrophone: true },
+				{ [WINDOWS_MIC_CAPTURE_MODE_ENV]: "typo" },
 			),
 		).toBe(false);
 	});
@@ -55,6 +64,15 @@ describe("shouldUseWindowsBrowserMicrophoneFallback", () => {
 		).toBe(true);
 	});
 
+	it("returns true when the native helper reports its stable fallback marker", () => {
+		expect(
+			shouldUseWindowsBrowserMicrophoneFallback(
+				"MICROPHONE_CAPTURE_UNAVAILABLE\nRecording started",
+				{ capturesMicrophone: true },
+			),
+		).toBe(true);
+	});
+
 	it("returns false when microphone capture was not requested", () => {
 		expect(
 			shouldUseWindowsBrowserMicrophoneFallback(
@@ -64,12 +82,12 @@ describe("shouldUseWindowsBrowserMicrophoneFallback", () => {
 		).toBe(false);
 	});
 
-	it("returns false for a healthy native mic when lab mode forces native capture", () => {
+	it("returns false for a healthy native mic by default", () => {
 		expect(
 			shouldUseWindowsBrowserMicrophoneFallback(
 				"Recording started",
 				{ capturesMicrophone: true },
-				{ [WINDOWS_MIC_CAPTURE_MODE_ENV]: "native" },
+				{},
 			),
 		).toBe(false);
 	});

--- a/electron/ipc/recording/windowsFallbacks.ts
+++ b/electron/ipc/recording/windowsFallbacks.ts
@@ -1,4 +1,7 @@
-const WINDOWS_MIC_CAPTURE_INIT_WARNING = "WARNING: Failed to initialize WASAPI mic capture";
+const WINDOWS_MIC_CAPTURE_UNAVAILABLE_MARKERS = [
+	"MICROPHONE_CAPTURE_UNAVAILABLE",
+	"WARNING: Failed to initialize WASAPI mic capture",
+];
 export const WINDOWS_MIC_CAPTURE_MODE_ENV = "RECORDLY_WINDOWS_MIC_CAPTURE";
 
 export function shouldStartWindowsBrowserMicrophoneFallback(
@@ -10,14 +13,8 @@ export function shouldStartWindowsBrowserMicrophoneFallback(
 	}
 
 	const mode = env[WINDOWS_MIC_CAPTURE_MODE_ENV]?.trim().toLowerCase();
-	if (mode === "native" || mode === "wasapi") {
-		return false;
-	}
-
-	if (!mode) {
-		return true;
-	}
-
+	// Native WASAPI is the normal Windows path. Keep the renderer path as an
+	// explicit escape hatch and as an automatic fallback when WASAPI cannot start.
 	return mode === "browser" || mode === "fallback" || mode === "renderer";
 }
 
@@ -29,6 +26,8 @@ export function shouldUseWindowsBrowserMicrophoneFallback(
 	return (
 		Boolean(options?.capturesMicrophone) &&
 		(shouldStartWindowsBrowserMicrophoneFallback(options, env) ||
-			captureOutput.includes(WINDOWS_MIC_CAPTURE_INIT_WARNING))
+			WINDOWS_MIC_CAPTURE_UNAVAILABLE_MARKERS.some((marker) =>
+				captureOutput.includes(marker),
+			))
 	);
 }

--- a/electron/ipc/register/recording.ts
+++ b/electron/ipc/register/recording.ts
@@ -531,6 +531,9 @@ export function registerRecordingHandlers(
 						);
 						config.captureMic = true;
 						config.micOutputPath = tempMicPath;
+						if (options.microphoneDeviceId) {
+							config.micDeviceId = options.microphoneDeviceId;
+						}
 						if (options.microphoneLabel) {
 							config.micDeviceName = options.microphoneLabel;
 						}

--- a/electron/native/wgc-capture/src/main.cpp
+++ b/electron/native/wgc-capture/src/main.cpp
@@ -24,12 +24,21 @@ static std::atomic<int64_t> g_accumulatedPausedHns{0};
 static std::mutex g_stopMutex;
 static std::condition_variable g_stopCv;
 
+static void reportMicrophoneCaptureUnavailable() {
+    std::cerr << "WARNING: Failed to initialize WASAPI mic capture" << std::endl;
+    // This stable stdout marker is ordered before "Recording started", allowing
+    // Electron to select its per-recording browser fallback without a pipe race.
+    std::cout << "MICROPHONE_CAPTURE_UNAVAILABLE" << std::endl;
+    std::cout.flush();
+}
+
 struct CaptureConfig {
     int64_t displayId = 0;
     int64_t windowHandle = 0;
     std::string outputPath;
     std::string audioOutputPath;
     std::string micOutputPath;
+    std::string micDeviceId;
     std::string micDeviceName;
     int fps = 60;
     int width = 0;
@@ -119,6 +128,7 @@ static bool parseSimpleJson(const std::string& json, CaptureConfig& config) {
 
     config.audioOutputPath = findString("audioOutputPath");
     config.micOutputPath = findString("micOutputPath");
+    config.micDeviceId = findString("micDeviceId");
     config.micDeviceName = findString("micDeviceName");
 
     auto findBool = [&](const std::string& key) -> bool {
@@ -342,6 +352,7 @@ int main(int argc, char* argv[]) {
     std::atomic<int64_t> frameCount{0};
     std::atomic<int64_t> firstVideoTimestampHns{-1};
     std::atomic<bool> recordingStartedAnnounced{false};
+    std::atomic<bool> captureSetupComplete{false};
     session.setFrameCallback([&](ID3D11Texture2D* texture, int64_t timestampHns) {
         g_lastFrameTimestampHns = timestampHns;
         int64_t expectedFirstVideoTimestampHns = -1;
@@ -354,7 +365,7 @@ int main(int argc, char* argv[]) {
 
         if (encoder.writeFrame(texture, adjustedTimestampHns)) {
             const int64_t writtenFrames = frameCount.fetch_add(1) + 1;
-            if (writtenFrames == 1 && !recordingStartedAnnounced.exchange(true)) {
+            if (captureSetupComplete && writtenFrames >= 1 && !recordingStartedAnnounced.exchange(true)) {
                 std::cout << "Recording started" << std::endl;
                 std::cout.flush();
             }
@@ -381,9 +392,12 @@ int main(int argc, char* argv[]) {
     }
 
     if (config.captureMic && !config.micOutputPath.empty()) {
-        micInitialized = micCapture.initializeMic(config.micOutputPath, config.micDeviceName);
+        micInitialized = micCapture.initializeMic(
+            config.micOutputPath,
+            config.micDeviceId,
+            config.micDeviceName);
         if (!micInitialized) {
-            std::cerr << "WARNING: Failed to initialize WASAPI mic capture" << std::endl;
+            reportMicrophoneCaptureUnavailable();
         }
     }
 
@@ -398,7 +412,11 @@ int main(int argc, char* argv[]) {
     }
     if (micInitialized) {
         micActive = micCapture.start();
+        if (!micActive) {
+            reportMicrophoneCaptureUnavailable();
+        }
     }
+    captureSetupComplete = true;
 
     // Wait for stop signal while pausing/resuming audio tracks in lockstep.
     while (!g_stopRequested && !session.hasFatalError()) {

--- a/electron/native/wgc-capture/src/wasapi_loopback.cpp
+++ b/electron/native/wgc-capture/src/wasapi_loopback.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <algorithm>
 #include <cmath>
+#include <cwctype>
 
 #pragma comment(lib, "ole32.lib")
 
@@ -54,6 +55,64 @@ int16_t pcm24ToInt16(const BYTE* sample) {
     }
     return static_cast<int16_t>(value >> 8);
 }
+
+std::wstring normalizeDeviceName(const std::wstring& value) {
+    std::wstring result;
+    result.reserve(value.size());
+    bool lastWasSpace = true;
+    for (const wchar_t character : value) {
+        if (std::iswalnum(character)) {
+            result.push_back(static_cast<wchar_t>(std::towlower(character)));
+            lastWasSpace = false;
+        } else if (!lastWasSpace) {
+            result.push_back(L' ');
+            lastWasSpace = true;
+        }
+    }
+    if (!result.empty() && result.back() == L' ') result.pop_back();
+    return result;
+}
+
+bool containsAsWords(const std::wstring& haystack, const std::wstring& needle) {
+    if (haystack.empty() || needle.empty()) return false;
+    size_t position = haystack.find(needle);
+    while (position != std::wstring::npos) {
+        const bool startsOnBoundary = position == 0 || haystack[position - 1] == L' ';
+        const size_t after = position + needle.size();
+        const bool endsOnBoundary = after == haystack.size() || haystack[after] == L' ';
+        if (startsOnBoundary && endsOnBoundary) return true;
+        position = haystack.find(needle, position + 1);
+    }
+    return false;
+}
+
+int scoreDeviceName(
+    const std::wstring& candidateName,
+    const std::wstring& candidateId,
+    const std::wstring& requestedName) {
+    const std::wstring candidate = normalizeDeviceName(candidateName);
+    const std::wstring id = normalizeDeviceName(candidateId);
+    const std::wstring requested = normalizeDeviceName(requestedName);
+    if (requested.empty()) return 0;
+    if (candidate == requested) return 1000;
+    if (containsAsWords(candidate, requested) || containsAsWords(requested, candidate)) return 900;
+    if (containsAsWords(id, requested) || containsAsWords(requested, id)) return 800;
+    return 0;
+}
+
+std::wstring getDeviceFriendlyName(IMMDevice* device) {
+    if (!device) return L"";
+    IPropertyStore* store = nullptr;
+    if (FAILED(device->OpenPropertyStore(STGM_READ, &store)) || !store) return L"";
+    PROPVARIANT value;
+    PropVariantInit(&value);
+    const HRESULT hr = store->GetValue(PKEY_Device_FriendlyName, &value);
+    std::wstring name;
+    if (SUCCEEDED(hr) && value.vt == VT_LPWSTR && value.pwszVal) name = value.pwszVal;
+    PropVariantClear(&value);
+    store->Release();
+    return name;
+}
 }
 
 static const CLSID CLSID_MMDeviceEnumerator_ = __uuidof(MMDeviceEnumerator);
@@ -88,28 +147,31 @@ IMMDevice* WasapiCapture::findCaptureDeviceByName(const std::wstring& targetName
     UINT count = 0;
     collection->GetCount(&count);
 
+    IMMDevice* bestDevice = nullptr;
+    int bestScore = 0;
     for (UINT i = 0; i < count; i++) {
         IMMDevice* dev = nullptr;
-        collection->Item(i, &dev);
+        if (FAILED(collection->Item(i, &dev)) || !dev) continue;
 
-        IPropertyStore* store = nullptr;
-        dev->OpenPropertyStore(STGM_READ, &store);
-        PROPVARIANT pv;
-        PropVariantInit(&pv);
-        store->GetValue(PKEY_Device_FriendlyName, &pv);
-        std::wstring name = pv.pwszVal ? pv.pwszVal : L"";
-        PropVariantClear(&pv);
-        store->Release();
-
-        if (name.find(targetName) != std::wstring::npos || targetName.find(name) != std::wstring::npos) {
-            collection->Release();
-            return dev;
+        LPWSTR rawId = nullptr;
+        std::wstring candidateId;
+        if (SUCCEEDED(dev->GetId(&rawId)) && rawId) {
+            candidateId = rawId;
+            CoTaskMemFree(rawId);
         }
-        dev->Release();
+        const std::wstring candidateName = getDeviceFriendlyName(dev);
+        const int score = scoreDeviceName(candidateName, candidateId, targetName);
+        if (score > bestScore) {
+            if (bestDevice) bestDevice->Release();
+            bestDevice = dev;
+            bestScore = score;
+        } else {
+            dev->Release();
+        }
     }
 
     collection->Release();
-    return nullptr;
+    return bestDevice;
 }
 
 bool WasapiCapture::initializeLoopback(const std::string& outputPath) {
@@ -127,7 +189,10 @@ bool WasapiCapture::initializeLoopback(const std::string& outputPath) {
     return initializeCommon();
 }
 
-bool WasapiCapture::initializeMic(const std::string& outputPath, const std::string& deviceName) {
+bool WasapiCapture::initializeMic(
+    const std::string& outputPath,
+    const std::string& deviceId,
+    const std::string& deviceName) {
     outputPath_ = outputPath;
     streamFlags_ = 0;
 
@@ -136,15 +201,23 @@ bool WasapiCapture::initializeMic(const std::string& outputPath, const std::stri
         IID_IMMDeviceEnumerator_, reinterpret_cast<void**>(&enumerator_));
     if (FAILED(hr)) return false;
 
-    if (!deviceName.empty()) {
+    if (!deviceId.empty() && deviceId != "default") {
+        const std::wstring requestedId = utf8ToWide(deviceId);
+        hr = enumerator_->GetDevice(requestedId.c_str(), &device_);
+        if (FAILED(hr)) device_ = nullptr;
+    }
+    if (!device_ && !deviceName.empty() && deviceId != "default") {
         device_ = findCaptureDeviceByName(utf8ToWide(deviceName));
     }
     if (!device_) {
-        hr = enumerator_->GetDefaultAudioEndpoint(eCapture, eCommunications, &device_);
-        if (FAILED(hr)) {
-            hr = enumerator_->GetDefaultAudioEndpoint(eCapture, eConsole, &device_);
-            if (FAILED(hr)) return false;
+        const bool wantedSpecificDevice =
+            deviceId != "default" && (!deviceId.empty() || !deviceName.empty());
+        if (wantedSpecificDevice) {
+            std::cerr << "WARNING: Requested microphone unavailable; using default WASAPI input"
+                      << std::endl;
         }
+        hr = enumerator_->GetDefaultAudioEndpoint(eCapture, eConsole, &device_);
+        if (FAILED(hr)) return false;
     }
 
     return initializeCommon();

--- a/electron/native/wgc-capture/src/wasapi_loopback.cpp
+++ b/electron/native/wgc-capture/src/wasapi_loopback.cpp
@@ -128,20 +128,27 @@ IMMDevice* WasapiCapture::findCaptureDeviceByName(const std::wstring& targetName
     UINT count = 0;
     collection->GetCount(&count);
 
+    IMMDevice* matchingDevice = nullptr;
     for (UINT i = 0; i < count; i++) {
         IMMDevice* dev = nullptr;
         if (FAILED(collection->Item(i, &dev)) || !dev) continue;
 
         const std::wstring candidateName = getDeviceFriendlyName(dev);
         if (deviceNamesMatch(candidateName, targetName)) {
-            collection->Release();
-            return dev;
+            if (matchingDevice) {
+                matchingDevice->Release();
+                dev->Release();
+                collection->Release();
+                return nullptr;
+            }
+            matchingDevice = dev;
+            continue;
         }
         dev->Release();
     }
 
     collection->Release();
-    return nullptr;
+    return matchingDevice;
 }
 
 bool WasapiCapture::initializeLoopback(const std::string& outputPath) {

--- a/electron/native/wgc-capture/src/wasapi_loopback.cpp
+++ b/electron/native/wgc-capture/src/wasapi_loopback.cpp
@@ -73,31 +73,12 @@ std::wstring normalizeDeviceName(const std::wstring& value) {
     return result;
 }
 
-bool containsAsWords(const std::wstring& haystack, const std::wstring& needle) {
-    if (haystack.empty() || needle.empty()) return false;
-    size_t position = haystack.find(needle);
-    while (position != std::wstring::npos) {
-        const bool startsOnBoundary = position == 0 || haystack[position - 1] == L' ';
-        const size_t after = position + needle.size();
-        const bool endsOnBoundary = after == haystack.size() || haystack[after] == L' ';
-        if (startsOnBoundary && endsOnBoundary) return true;
-        position = haystack.find(needle, position + 1);
-    }
-    return false;
-}
-
-int scoreDeviceName(
+bool deviceNamesMatch(
     const std::wstring& candidateName,
-    const std::wstring& candidateId,
     const std::wstring& requestedName) {
     const std::wstring candidate = normalizeDeviceName(candidateName);
-    const std::wstring id = normalizeDeviceName(candidateId);
     const std::wstring requested = normalizeDeviceName(requestedName);
-    if (requested.empty()) return 0;
-    if (candidate == requested) return 1000;
-    if (containsAsWords(candidate, requested) || containsAsWords(requested, candidate)) return 900;
-    if (containsAsWords(id, requested) || containsAsWords(requested, id)) return 800;
-    return 0;
+    return !candidate.empty() && candidate == requested;
 }
 
 std::wstring getDeviceFriendlyName(IMMDevice* device) {
@@ -147,31 +128,20 @@ IMMDevice* WasapiCapture::findCaptureDeviceByName(const std::wstring& targetName
     UINT count = 0;
     collection->GetCount(&count);
 
-    IMMDevice* bestDevice = nullptr;
-    int bestScore = 0;
     for (UINT i = 0; i < count; i++) {
         IMMDevice* dev = nullptr;
         if (FAILED(collection->Item(i, &dev)) || !dev) continue;
 
-        LPWSTR rawId = nullptr;
-        std::wstring candidateId;
-        if (SUCCEEDED(dev->GetId(&rawId)) && rawId) {
-            candidateId = rawId;
-            CoTaskMemFree(rawId);
-        }
         const std::wstring candidateName = getDeviceFriendlyName(dev);
-        const int score = scoreDeviceName(candidateName, candidateId, targetName);
-        if (score > bestScore) {
-            if (bestDevice) bestDevice->Release();
-            bestDevice = dev;
-            bestScore = score;
-        } else {
-            dev->Release();
+        if (deviceNamesMatch(candidateName, targetName)) {
+            collection->Release();
+            return dev;
         }
+        dev->Release();
     }
 
     collection->Release();
-    return bestDevice;
+    return nullptr;
 }
 
 bool WasapiCapture::initializeLoopback(const std::string& outputPath) {
@@ -213,8 +183,8 @@ bool WasapiCapture::initializeMic(
         const bool wantedSpecificDevice =
             deviceId != "default" && (!deviceId.empty() || !deviceName.empty());
         if (wantedSpecificDevice) {
-            std::cerr << "WARNING: Requested microphone unavailable; using default WASAPI input"
-                      << std::endl;
+            std::cerr << "WARNING: Requested microphone unavailable" << std::endl;
+            return false;
         }
         hr = enumerator_->GetDefaultAudioEndpoint(eCapture, eConsole, &device_);
         if (FAILED(hr)) return false;

--- a/electron/native/wgc-capture/src/wasapi_loopback.h
+++ b/electron/native/wgc-capture/src/wasapi_loopback.h
@@ -14,7 +14,10 @@ public:
     ~WasapiCapture();
 
     bool initializeLoopback(const std::string& outputPath);
-    bool initializeMic(const std::string& outputPath, const std::string& deviceName = "");
+    bool initializeMic(
+        const std::string& outputPath,
+        const std::string& deviceId = "",
+        const std::string& deviceName = "");
     bool start();
     bool pause();
     bool resume();


### PR DESCRIPTION
## Description

Windows recordings now capture the microphone through native WASAPI by default instead of routing it through Chromium. The selected microphone is resolved by device ID and then by an exact normalized name match.

If a specifically selected microphone cannot be resolved, or WASAPI cannot initialize or start, Recordly automatically uses the existing browser microphone fallback for that recording. The browser path can still be forced with `RECORDLY_WINDOWS_MIC_CAPTURE=browser`.

The native helper reports microphone startup failures before it reports that recording has started, preventing a race that could otherwise leave a recording without microphone audio.

## Motivation

The browser microphone path enables Chromium audio processing and has produced crackling on some Windows devices. Windows already records the screen through the native helper, so using native WASAPI for the microphone avoids that processing while retaining a safe fallback.

## Type of Change

- [x] New Feature
- [x] Bug Fix
- [ ] Refactor / Code Cleanup
- [ ] Documentation Update
- [ ] Other

## Related Issue(s)

None.

## Screenshots / Video

Not applicable; there are no user-interface changes.

## Testing Guide

1. On Windows, select a microphone and start a screen recording.
2. Speak during the recording, then stop and confirm the microphone track plays in the editor.
3. Repeat with pause and resume.
4. Select or disconnect an unavailable microphone and confirm recording continues using the browser microphone fallback.
5. Set `RECORDLY_WINDOWS_MIC_CAPTURE=browser` and confirm the forced fallback still works.

Automated validation completed:

- `npm test` (1,105 tests)
- `npx tsc --noEmit`
- Biome checks on the changed TypeScript files
- `git diff --check`

The native Windows helper is compiled by the Windows CI runner because the local development host is macOS.

## Checklist

- [x] I have performed a self-review of my code.
- [x] Screenshots or videos are not applicable.
- [x] There is no related issue; no changelog update is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Windows recordings now use the selected microphone device more reliably, including devices chosen by ID.
  - Browser-based microphone fallback starts when native capture is unavailable.

- **Bug Fixes**
  - Improved matching for specifically selected microphones to prevent recording from the wrong device.
  - Windows microphone capture now defaults to the native capture path and handles unrecognized settings consistently.
  - Recording status is announced only after capture setup succeeds and frames begin recording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->